### PR TITLE
Trajectory output

### DIFF
--- a/robowflex_library/include/robowflex_library/benchmarking.h
+++ b/robowflex_library/include/robowflex_library/benchmarking.h
@@ -1,13 +1,10 @@
 #ifndef ROBOWFLEX_BENCHMARKING_
 #define ROBOWFLEX_BENCHMARKING_
 
-#include <robowflex_library/util.h>
-
 namespace robowflex
 {
     // Forward Declaration.
-    class BenchmarkOutputter;
-    typedef std::shared_ptr<BenchmarkOutputter> BenchmarkOutputterPtr;
+    ROBOWFLEX_CLASS_FORWARD(BenchmarkOutputter);
 
     class Benchmarker
     {
@@ -80,10 +77,6 @@ namespace robowflex
     class BenchmarkOutputter
     {
     public:
-        BenchmarkOutputter()
-        {
-        }
-
         virtual ~BenchmarkOutputter() = default;
 
         // Write one unit of output (usually a single planner) to the output.
@@ -93,7 +86,7 @@ namespace robowflex
     class JSONBenchmarkOutputter : public BenchmarkOutputter
     {
     public:
-        JSONBenchmarkOutputter(const std::string &file) : BenchmarkOutputter(), file_(file)
+        JSONBenchmarkOutputter(const std::string &file) : file_(file)
         {
         }
 
@@ -107,10 +100,10 @@ namespace robowflex
         std::ofstream outfile_;
     };
 
-    class TrajectoryOutputter : public BenchmarkOutputter
+    class TrajectoryBenchmarkOutputter : public BenchmarkOutputter
     {
     public:
-        TrajectoryOutputter(const std::string &file) : BenchmarkOutputter(), file_(file), bag_(file_)
+        TrajectoryBenchmarkOutputter(const std::string &file) : file_(file), bag_(file_)
         {
         }
 
@@ -121,15 +114,15 @@ namespace robowflex
          * The trajectories found by each request are stored in a topic of
          * the request name in a bag file of the given name.
          */
-        std::string file_;
         bool is_init_{false};
+        const std::string file_;
         IO::Bag bag_;
     };
 
     class OMPLBenchmarkOutputter : public BenchmarkOutputter
     {
     public:
-        OMPLBenchmarkOutputter(const std::string &prefix) : BenchmarkOutputter(), prefix_(prefix)
+        OMPLBenchmarkOutputter(const std::string &prefix) : prefix_(prefix)
         {
         }
 

--- a/robowflex_library/include/robowflex_library/robowflex.h
+++ b/robowflex_library/include/robowflex_library/robowflex.h
@@ -2,6 +2,7 @@
 #define ROBOWFLEX_
 
 #include <fstream>
+#include <memory>
 
 #include <yaml-cpp/yaml.h>
 
@@ -16,6 +17,10 @@
 
 // #include <moveit/ompl_interface/ompl_interface.h>
 // #include <moveit/ompl_interface/model_based_planning_context.h>
+
+#define ROBOWFLEX_CLASS_FORWARD(C)                                                                           \
+    class C;                                                                                                 \
+    typedef std::shared_ptr<C> C##Ptr
 
 #define ROBOWFLEX_AT_LEAST_INDIGO ROS_VERSION_MINIMUM(1, 11, 0)
 #define ROBOWFLEX_AT_LEAST_LUNAR ROS_VERSION_MINIMUM(1, 12, 0)

--- a/robowflex_library/scripts/ur5_benchmark.cpp
+++ b/robowflex_library/scripts/ur5_benchmark.cpp
@@ -37,10 +37,7 @@ int main(int argc, char **argv)
     benchmark.addBenchmarkingRequest("joint", scene, planner, joint_request);
     benchmark.addBenchmarkingRequest("pose", scene, planner, pose_request);
 
-    BenchmarkOutputterPtr out(new OMPLBenchmarkOutputter("robowflex_ur5_test/"));
-    std::vector<BenchmarkOutputterPtr> outs;
-    outs.push_back(out);
-    benchmark.benchmark(outs);
+    benchmark.benchmark({std::make_shared<OMPLBenchmarkOutputter>("robowflex_ur5_test/")});
 
     return 0;
 }

--- a/robowflex_library/scripts/wam7_benchmark.cpp
+++ b/robowflex_library/scripts/wam7_benchmark.cpp
@@ -10,7 +10,7 @@ int main(int argc, char **argv)
     startROS(argc, argv);
 
     Robot wam7("wam7");
-    wam7.initialize("package://barrett_model/robots/wam7_bhand.urdf.xacro",  // urdf
+    wam7.initialize("package://barrett_model/robots/wam7_bhand.urdf.xacro",          // urdf
                     "package://barrett_wam_moveit_config/config/wam7_hand.srdf",     // srdf
                     "package://barrett_wam_moveit_config/config/joint_limits.yaml",  // joint limits
                     "package://barrett_wam_moveit_config/config/kinematics.yaml"     // kinematics
@@ -31,12 +31,7 @@ int main(int argc, char **argv)
     Benchmarker benchmark;
     benchmark.addBenchmarkingRequest("test", scene, planner, request);
 
-    BenchmarkOutputterPtr out_json(new JSONBenchmarkOutputter("test_log.json"));
-    BenchmarkOutputterPtr out_traj(new TrajectoryOutputter("test_log.bag"));
-    std::vector<BenchmarkOutputterPtr> outs;
-    outs.push_back(out_json);
-    outs.push_back(out_traj);
-    benchmark.benchmark(outs);
-
+    benchmark.benchmark({std::make_shared<JSONBenchmarkOutputter>("test_log.json"),  //
+                         std::make_shared<TrajectoryBenchmarkOutputter>("test_log.bag")});
     return 0;
 }

--- a/robowflex_library/src/benchmarking.cpp
+++ b/robowflex_library/src/benchmarking.cpp
@@ -47,10 +47,9 @@ void Benchmarker::benchmark(const std::vector<BenchmarkOutputterPtr> &outputs, c
         }
 
         results.finish = IO::getDate();
+
         for (BenchmarkOutputterPtr output : outputs)
-        {
             output->dumpResult(results);
-        }
     }
 }
 
@@ -145,9 +144,7 @@ void JSONBenchmarkOutputter::dumpResult(const Benchmarker::Results &results)
         is_init_ = true;
     }
     else
-    {
         outfile_ << ",";
-    }
 
     outfile_ << "\"" << results.name << "\":[";
 
@@ -184,13 +181,12 @@ JSONBenchmarkOutputter::~JSONBenchmarkOutputter()
     outfile_.close();
 }
 
-void TrajectoryOutputter::dumpResult(const Benchmarker::Results &results)
+void TrajectoryBenchmarkOutputter::dumpResult(const Benchmarker::Results &results)
 {
     const std::string &name = results.name;
+
     for (Benchmarker::Results::Run run : results.runs)
-    {
         bag_.addMessage(name, run.path);
-    }
 }
 
 void OMPLBenchmarkOutputter::dumpResult(const Benchmarker::Results &results)


### PR DESCRIPTION
Adds the ability to output trajectories to a bag file so you can further analyze them sometime in the future.

All the trajectories from each result are stored on their own topic in the bag file, the same as the result's name.