### PR TITLE
MoveIt! Melodic Update

### DIFF
--- a/robowflex_doc/doc/markdown/design.md
+++ b/robowflex_doc/doc/markdown/design.md
@@ -68,6 +68,18 @@ See the [readme](robowflex_visualization/README.html) for more details.
 
 Additionally, there are a few implementations of robowflex::Robot for some commonly used robots, such as robowflex::UR5Robot, robowflex::FetchRobot, and robowflex::R2Robot.
 
+## Compatibility
+
+Robowflex strives to maintain compatibility with all commonly used ROS distributions, from Indigo to Melodic.
+To this end, there are many adapters and internal constructs so that users can run Robowflex in any of these environments without modification.
+However, there are some things to note about how various internal APIs have changed and how this affects behavior:
+- robowflex::ROS will attempt to spin up an instance of `rosmaster` if one is not already running only on Melodic onward, due to a dependency of how this is implemented on Boost 1.64.
+- _MoveIt!_ changed from using `Eigen::Affine3d` as the representation of transformation matrices to `Eigen::Isometry3d` in Melodic in version 0.10.6. To account for this, we provide `robowflex::RobotPose` which is a type alias for the correct matrix representation.
+- YAML output does not "flow" output on Indigo for more concise files. 
+
+Note that there are other internal functions that account for API differences between ROS versions, but they are not relevant to user code.
+There are macros in [`macros.h`](macros_8h_source.html) that allow for conditional compilation on versions.
+
 ## Documentation
 
 All documentation (through [Doxygen](http://www.stack.nl/~dimitri/doxygen/)) is done in the `robowflex_doc` package.

--- a/robowflex_doc/doc/tag/moveit_core.tag
+++ b/robowflex_doc/doc/tag/moveit_core.tag
@@ -392,14 +392,14 @@
       <name>transform2fcl</name>
       <anchorfile>namespacecollision__detection.html</anchorfile>
       <anchor>ac62f07a0d167ce0255db6ab31b9506bb</anchor>
-      <arglist>(const Eigen::Affine3d &amp;b, fcl::Transform3f &amp;f)</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;b, fcl::Transform3f &amp;f)</arglist>
     </member>
     <member kind="function">
       <type>fcl::Transform3f</type>
       <name>transform2fcl</name>
       <anchorfile>namespacecollision__detection.html</anchorfile>
       <anchor>a65033c779e897cf789d2be527fc26be2</anchor>
-      <arglist>(const Eigen::Affine3d &amp;b)</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;b)</arglist>
     </member>
   </compound>
   <compound kind="file">
@@ -1885,7 +1885,7 @@
       <arglist></arglist>
     </member>
     <member kind="typedef">
-      <type>std::map&lt; const LinkModel *, Eigen::Affine3d, std::less&lt; const LinkModel * &gt;, Eigen::aligned_allocator&lt; std::pair&lt; const LinkModel *const, Eigen::Affine3d &gt; &gt; &gt;</type>
+      <type>std::map&lt; const LinkModel *, Eigen::Isometry3d, std::less&lt; const LinkModel * &gt;, Eigen::aligned_allocator&lt; std::pair&lt; const LinkModel *const, Eigen::Isometry3d &gt; &gt; &gt;</type>
       <name>LinkTransformMap</name>
       <anchorfile>namespacemoveit_1_1core.html</anchorfile>
       <anchor>a4586cb570da059f7f173b6fd9f358917</anchor>
@@ -3541,7 +3541,7 @@
     <namespace>moveit</namespace>
     <namespace>moveit::core</namespace>
     <member kind="typedef">
-      <type>std::map&lt; std::string, Eigen::Affine3d, std::less&lt; std::string &gt;, Eigen::aligned_allocator&lt; std::pair&lt; const std::string, Eigen::Affine3d &gt; &gt; &gt;</type>
+      <type>std::map&lt; std::string, Eigen::Isometry3d, std::less&lt; std::string &gt;, Eigen::aligned_allocator&lt; std::pair&lt; const std::string, Eigen::Isometry3d &gt; &gt; &gt;</type>
       <name>FixedTransformsMap</name>
       <anchorfile>namespacemoveit_1_1core.html</anchorfile>
       <anchor>aab2e7121788a9fdfc2ca8ad2fc2f78a2</anchor>
@@ -3755,7 +3755,7 @@
       <name>extendWithTransformedBox</name>
       <anchorfile>classmoveit_1_1core_1_1AABB.html</anchorfile>
       <anchor>a82a6a42a7e743906c9f4b607cc4143e3</anchor>
-      <arglist>(const Eigen::Affine3d &amp;transform, const Eigen::Vector3d &amp;box)</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;transform, const Eigen::Vector3d &amp;box)</arglist>
     </member>
   </compound>
   <compound kind="class">
@@ -4019,14 +4019,14 @@
       <name>AttachedBody</name>
       <anchorfile>classmoveit_1_1core_1_1AttachedBody.html</anchorfile>
       <anchor>a50282a5a8ed6a2b6447d9245de71e663</anchor>
-      <arglist>(const LinkModel *link, const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Affine3d &amp;attach_trans, const std::set&lt; std::string &gt; &amp;touch_links, const trajectory_msgs::JointTrajectory &amp;attach_posture)</arglist>
+      <arglist>(const LinkModel *link, const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Isometry3d &amp;attach_trans, const std::set&lt; std::string &gt; &amp;touch_links, const trajectory_msgs::JointTrajectory &amp;attach_posture)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
       <name>computeTransform</name>
       <anchorfile>classmoveit_1_1core_1_1AttachedBody.html</anchorfile>
       <anchor>a7f5205d9981c02ffb6b5758babdc1ef0</anchor>
-      <arglist>(const Eigen::Affine3d &amp;parent_link_global_transform)</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;parent_link_global_transform)</arglist>
     </member>
     <member kind="function">
       <type>const LinkModel *</type>
@@ -4050,14 +4050,14 @@
       <arglist>() const </arglist>
     </member>
     <member kind="function">
-      <type>const EigenSTL::vector_Affine3d &amp;</type>
+      <type>const EigenSTL::vector_Isometry3d &amp;</type>
       <name>getFixedTransforms</name>
       <anchorfile>classmoveit_1_1core_1_1AttachedBody.html</anchorfile>
       <anchor>aed0f2b8b0374c5080e646cb730e8f1dc</anchor>
       <arglist>() const </arglist>
     </member>
     <member kind="function">
-      <type>const EigenSTL::vector_Affine3d &amp;</type>
+      <type>const EigenSTL::vector_Isometry3d &amp;</type>
       <name>getGlobalCollisionBodyTransforms</name>
       <anchorfile>classmoveit_1_1core_1_1AttachedBody.html</anchorfile>
       <anchor>a68a3503d854abacd63fc2ad59d737049</anchor>
@@ -4106,7 +4106,7 @@
       <arglist>()</arglist>
     </member>
     <member kind="variable" protection="private">
-      <type>EigenSTL::vector_Affine3d</type>
+      <type>EigenSTL::vector_Isometry3d</type>
       <name>attach_trans_</name>
       <anchorfile>classmoveit_1_1core_1_1AttachedBody.html</anchorfile>
       <anchor>a53b1c393e8a81431f9eeff9c4d4f4235</anchor>
@@ -4120,7 +4120,7 @@
       <arglist></arglist>
     </member>
     <member kind="variable" protection="private">
-      <type>EigenSTL::vector_Affine3d</type>
+      <type>EigenSTL::vector_Isometry3d</type>
       <name>global_collision_body_transforms_</name>
       <anchorfile>classmoveit_1_1core_1_1AttachedBody.html</anchorfile>
       <anchor>a9aa1ab1823fc1ad413f7cbb1c0204e8e</anchor>
@@ -6431,7 +6431,7 @@
       <name>addShapeToField</name>
       <anchorfile>classdistance__field_1_1DistanceField.html</anchorfile>
       <anchor>adeca93ccdc0704a448e56a77f9a3b8cd</anchor>
-      <arglist>(const shapes::Shape *shape, const Eigen::Affine3d &amp;pose)</arglist>
+      <arglist>(const shapes::Shape *shape, const Eigen::Isometry3d &amp;pose)</arglist>
     </member>
     <member kind="function">
       <type>MOVEIT_DEPRECATED void</type>
@@ -6529,7 +6529,7 @@
       <name>getShapePoints</name>
       <anchorfile>classdistance__field_1_1DistanceField.html</anchorfile>
       <anchor>abd7ae7db9c6791d12199ee0c7226b98b</anchor>
-      <arglist>(const shapes::Shape *shape, const Eigen::Affine3d &amp;pose, EigenSTL::vector_Vector3d *points)</arglist>
+      <arglist>(const shapes::Shape *shape, const Eigen::Isometry3d &amp;pose, EigenSTL::vector_Vector3d *points)</arglist>
     </member>
     <member kind="function">
       <type>double</type>
@@ -6599,7 +6599,7 @@
       <name>moveShapeInField</name>
       <anchorfile>classdistance__field_1_1DistanceField.html</anchorfile>
       <anchor>ab53c792990adde7bb6fbf3acd39d3a01</anchor>
-      <arglist>(const shapes::Shape *shape, const Eigen::Affine3d &amp;old_pose, const Eigen::Affine3d &amp;new_pose)</arglist>
+      <arglist>(const shapes::Shape *shape, const Eigen::Isometry3d &amp;old_pose, const Eigen::Isometry3d &amp;new_pose)</arglist>
     </member>
     <member kind="function">
       <type>MOVEIT_DEPRECATED void</type>
@@ -6627,7 +6627,7 @@
       <name>removeShapeFromField</name>
       <anchorfile>classdistance__field_1_1DistanceField.html</anchorfile>
       <anchor>a6f5841f58cf2362b0d9cb2b3d98b172b</anchor>
-      <arglist>(const shapes::Shape *shape, const Eigen::Affine3d &amp;pose)</arglist>
+      <arglist>(const shapes::Shape *shape, const Eigen::Isometry3d &amp;pose)</arglist>
     </member>
     <member kind="function">
       <type>MOVEIT_DEPRECATED void</type>
@@ -7478,14 +7478,14 @@
       <name>computeTransform</name>
       <anchorfile>classmoveit_1_1core_1_1FixedJointModel.html</anchorfile>
       <anchor>a24aa6ee9adc1039fd0524665f60c2af0</anchor>
-      <arglist>(const double *joint_values, Eigen::Affine3d &amp;transf) const </arglist>
+      <arglist>(const double *joint_values, Eigen::Isometry3d &amp;transf) const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
       <type>virtual void</type>
       <name>computeVariablePositions</name>
       <anchorfile>classmoveit_1_1core_1_1FixedJointModel.html</anchorfile>
       <anchor>a5a47a4b4ebc0c550ce2b382252290d1f</anchor>
-      <arglist>(const Eigen::Affine3d &amp;transf, double *joint_values) const </arglist>
+      <arglist>(const Eigen::Isometry3d &amp;transf, double *joint_values) const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
       <type>virtual double</type>
@@ -7567,14 +7567,14 @@
       <name>computeTransform</name>
       <anchorfile>classmoveit_1_1core_1_1FloatingJointModel.html</anchorfile>
       <anchor>a73a9f5c83ab6080ba7fcc290ffe77072</anchor>
-      <arglist>(const double *joint_values, Eigen::Affine3d &amp;transf) const </arglist>
+      <arglist>(const double *joint_values, Eigen::Isometry3d &amp;transf) const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
       <type>virtual void</type>
       <name>computeVariablePositions</name>
       <anchorfile>classmoveit_1_1core_1_1FloatingJointModel.html</anchorfile>
       <anchor>a2fde7bc379a64403afa3718ce3a98074</anchor>
-      <arglist>(const Eigen::Affine3d &amp;transf, double *joint_values) const </arglist>
+      <arglist>(const Eigen::Isometry3d &amp;transf, double *joint_values) const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
       <type>virtual double</type>
@@ -7894,7 +7894,7 @@
       <arglist>(robot_state::RobotState &amp;state) const </arglist>
     </member>
     <member kind="variable" protection="protected">
-      <type>Eigen::Affine3d</type>
+      <type>Eigen::Isometry3d</type>
       <name>eef_to_ik_tip_transform_</name>
       <anchorfile>classconstraint__samplers_1_1IKConstraintSampler.html</anchorfile>
       <anchor>a573d61474cda1c99f285b3d12744786c</anchor>
@@ -8911,14 +8911,14 @@
       <name>computeTransform</name>
       <anchorfile>classmoveit_1_1core_1_1JointModel.html</anchorfile>
       <anchor>a58d9998af67f3e9d00847813131cb728</anchor>
-      <arglist>(const double *joint_values, Eigen::Affine3d &amp;transf) const =0</arglist>
+      <arglist>(const double *joint_values, Eigen::Isometry3d &amp;transf) const =0</arglist>
     </member>
     <member kind="function" virtualness="pure">
       <type>virtual void</type>
       <name>computeVariablePositions</name>
       <anchorfile>classmoveit_1_1core_1_1JointModel.html</anchorfile>
       <anchor>a5dc64747f5bc73a9cdfd91e149aa2976</anchor>
-      <arglist>(const Eigen::Affine3d &amp;transform, double *joint_values) const =0</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;transform, double *joint_values) const =0</arglist>
     </member>
     <member kind="function" protection="protected">
       <type>void</type>
@@ -9268,14 +9268,14 @@
       <name>computeTransform</name>
       <anchorfile>classmoveit_1_1core_1_1JointModel.html</anchorfile>
       <anchor>a58d9998af67f3e9d00847813131cb728</anchor>
-      <arglist>(const double *joint_values, Eigen::Affine3d &amp;transf) const =0</arglist>
+      <arglist>(const double *joint_values, Eigen::Isometry3d &amp;transf) const =0</arglist>
     </member>
     <member kind="function" virtualness="pure">
       <type>virtual void</type>
       <name>computeVariablePositions</name>
       <anchorfile>classmoveit_1_1core_1_1JointModel.html</anchorfile>
       <anchor>a5dc64747f5bc73a9cdfd91e149aa2976</anchor>
-      <arglist>(const Eigen::Affine3d &amp;transform, double *joint_values) const =0</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;transform, double *joint_values) const =0</arglist>
     </member>
   </compound>
   <compound kind="class">
@@ -11155,7 +11155,7 @@
       <name>addAssociatedFixedTransform</name>
       <anchorfile>classmoveit_1_1core_1_1LinkModel.html</anchorfile>
       <anchor>a9fc0ba69509b6e9c3e29cc57cfad2ecd</anchor>
-      <arglist>(const LinkModel *link_model, const Eigen::Affine3d &amp;transform)</arglist>
+      <arglist>(const LinkModel *link_model, const Eigen::Isometry3d &amp;transform)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
@@ -11193,7 +11193,7 @@
       <arglist>() const </arglist>
     </member>
     <member kind="function">
-      <type>const EigenSTL::vector_Affine3d &amp;</type>
+      <type>const EigenSTL::vector_Isometry3d &amp;</type>
       <name>getCollisionOriginTransforms</name>
       <anchorfile>classmoveit_1_1core_1_1LinkModel.html</anchorfile>
       <anchor>a27033b95e367e248d477ea0d4d260fc8</anchor>
@@ -11207,7 +11207,7 @@
       <arglist>() const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getJointOriginTransform</name>
       <anchorfile>classmoveit_1_1core_1_1LinkModel.html</anchorfile>
       <anchor>a0b68ee7f94f0f0b9cc8c4b0af2b78aec</anchor>
@@ -11263,7 +11263,7 @@
       <arglist>() const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getVisualMeshOrigin</name>
       <anchorfile>classmoveit_1_1core_1_1LinkModel.html</anchorfile>
       <anchor>a29994d4244e57486d6292f6c1db95184</anchor>
@@ -11309,14 +11309,14 @@
       <name>setGeometry</name>
       <anchorfile>classmoveit_1_1core_1_1LinkModel.html</anchorfile>
       <anchor>a77830405460333197be4ba84af70ec06</anchor>
-      <arglist>(const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Affine3d &amp;origins)</arglist>
+      <arglist>(const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Isometry3d &amp;origins)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
       <name>setJointOriginTransform</name>
       <anchorfile>classmoveit_1_1core_1_1LinkModel.html</anchorfile>
       <anchor>ac742dc6c7e8f9fb99497dfb505df906e</anchor>
-      <arglist>(const Eigen::Affine3d &amp;transform)</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;transform)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
@@ -11344,7 +11344,7 @@
       <name>setVisualMesh</name>
       <anchorfile>classmoveit_1_1core_1_1LinkModel.html</anchorfile>
       <anchor>a4589c754516558e0214c2263c3d58583</anchor>
-      <arglist>(const std::string &amp;visual_mesh, const Eigen::Affine3d &amp;origin, const Eigen::Vector3d &amp;scale)</arglist>
+      <arglist>(const std::string &amp;visual_mesh, const Eigen::Isometry3d &amp;origin, const Eigen::Vector3d &amp;scale)</arglist>
     </member>
     <member kind="function">
       <type></type>
@@ -11375,7 +11375,7 @@
       <arglist></arglist>
     </member>
     <member kind="variable" protection="private">
-      <type>EigenSTL::vector_Affine3d</type>
+      <type>EigenSTL::vector_Isometry3d</type>
       <name>collision_origin_transform_</name>
       <anchorfile>classmoveit_1_1core_1_1LinkModel.html</anchorfile>
       <anchor>ad2409c58aff489b6051c53c89546e35f</anchor>
@@ -11403,7 +11403,7 @@
       <arglist></arglist>
     </member>
     <member kind="variable" protection="private">
-      <type>Eigen::Affine3d</type>
+      <type>Eigen::Isometry3d</type>
       <name>joint_origin_transform_</name>
       <anchorfile>classmoveit_1_1core_1_1LinkModel.html</anchorfile>
       <anchor>ae73aa3cbb0f036a34574bbb2dd3f02b2</anchor>
@@ -11466,7 +11466,7 @@
       <arglist></arglist>
     </member>
     <member kind="variable" protection="private">
-      <type>Eigen::Affine3d</type>
+      <type>Eigen::Isometry3d</type>
       <name>visual_mesh_origin_</name>
       <anchorfile>classmoveit_1_1core_1_1LinkModel.html</anchorfile>
       <anchor>a33143600ddb0a187d075b94b4de7636d</anchor>
@@ -11947,7 +11947,7 @@
       <arglist></arglist>
     </member>
     <member kind="variable">
-      <type>EigenSTL::vector_Affine3d</type>
+      <type>EigenSTL::vector_Isometry3d</type>
       <name>shape_poses_</name>
       <anchorfile>structcollision__detection_1_1World_1_1Object.html</anchorfile>
       <anchor>a1ee0807d07eacee16e5b9a786ba2e5a5</anchor>
@@ -12240,14 +12240,14 @@
       <name>computeTransform</name>
       <anchorfile>classmoveit_1_1core_1_1PlanarJointModel.html</anchorfile>
       <anchor>ae62107a4a676278e0be770d1d56c3fa4</anchor>
-      <arglist>(const double *joint_values, Eigen::Affine3d &amp;transf) const </arglist>
+      <arglist>(const double *joint_values, Eigen::Isometry3d &amp;transf) const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
       <type>virtual void</type>
       <name>computeVariablePositions</name>
       <anchorfile>classmoveit_1_1core_1_1PlanarJointModel.html</anchorfile>
       <anchor>ab492618a1e8ca28431ba8503a20a1112</anchor>
-      <arglist>(const Eigen::Affine3d &amp;transf, double *joint_values) const </arglist>
+      <arglist>(const Eigen::Isometry3d &amp;transf, double *joint_values) const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
       <type>virtual double</type>
@@ -13018,7 +13018,7 @@
       <name>loadGeometryFromStream</name>
       <anchorfile>classplanning__scene_1_1PlanningScene.html</anchorfile>
       <anchor>aa0310b2032f5ad24d658c5ff9653163a</anchor>
-      <arglist>(std::istream &amp;in, const Eigen::Affine3d &amp;offset)</arglist>
+      <arglist>(std::istream &amp;in, const Eigen::Isometry3d &amp;offset)</arglist>
     </member>
     <member kind="function">
       <type></type>
@@ -13074,7 +13074,7 @@
       <name>processOctomapPtr</name>
       <anchorfile>classplanning__scene_1_1PlanningScene.html</anchorfile>
       <anchor>ab1f85fd67f7dfbf7457e6f3c871d78de</anchor>
-      <arglist>(const std::shared_ptr&lt; const octomap::OcTree &gt; &amp;octree, const Eigen::Affine3d &amp;t)</arglist>
+      <arglist>(const std::shared_ptr&lt; const octomap::OcTree &gt; &amp;octree, const Eigen::Isometry3d &amp;t)</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
@@ -13238,28 +13238,28 @@
       <arglist>()</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getFrameTransform</name>
       <anchorfile>classplanning__scene_1_1PlanningScene.html</anchorfile>
       <anchor>a4239584551cf1cfa096cdbbb04d2b38b</anchor>
       <arglist>(const std::string &amp;id) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getFrameTransform</name>
       <anchorfile>classplanning__scene_1_1PlanningScene.html</anchorfile>
       <anchor>a9c012948fb1348b66355479d4e5b1995</anchor>
       <arglist>(const std::string &amp;id)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getFrameTransform</name>
       <anchorfile>classplanning__scene_1_1PlanningScene.html</anchorfile>
       <anchor>a0e195d135e74bc0962c2e9bedcd9bd7f</anchor>
       <arglist>(robot_state::RobotState &amp;state, const std::string &amp;id) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getFrameTransform</name>
       <anchorfile>classplanning__scene_1_1PlanningScene.html</anchorfile>
       <anchor>adc05ef0c260fa0b0fa7705e722467eae</anchor>
@@ -13959,28 +13959,28 @@
       <arglist>()</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getFrameTransform</name>
       <anchorfile>classplanning__scene_1_1PlanningScene.html</anchorfile>
       <anchor>a4239584551cf1cfa096cdbbb04d2b38b</anchor>
       <arglist>(const std::string &amp;id) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getFrameTransform</name>
       <anchorfile>classplanning__scene_1_1PlanningScene.html</anchorfile>
       <anchor>a9c012948fb1348b66355479d4e5b1995</anchor>
       <arglist>(const std::string &amp;id)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getFrameTransform</name>
       <anchorfile>classplanning__scene_1_1PlanningScene.html</anchorfile>
       <anchor>a0e195d135e74bc0962c2e9bedcd9bd7f</anchor>
       <arglist>(robot_state::RobotState &amp;state, const std::string &amp;id) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getFrameTransform</name>
       <anchorfile>classplanning__scene_1_1PlanningScene.html</anchorfile>
       <anchor>adc05ef0c260fa0b0fa7705e722467eae</anchor>
@@ -14531,7 +14531,7 @@
       <arglist></arglist>
     </member>
     <member kind="variable" protection="protected">
-      <type>EigenSTL::vector_Affine3d</type>
+      <type>EigenSTL::vector_Isometry3d</type>
       <name>constraint_region_pose_</name>
       <anchorfile>classkinematic__constraints_1_1PositionConstraint.html</anchorfile>
       <anchor>a06f4ea1fb49bef174b0e14c2668a5741</anchor>
@@ -15043,14 +15043,14 @@
       <name>computeTransform</name>
       <anchorfile>classmoveit_1_1core_1_1PrismaticJointModel.html</anchorfile>
       <anchor>a6f0384b6e6df5ae95bb92e61d0dcd228</anchor>
-      <arglist>(const double *joint_values, Eigen::Affine3d &amp;transf) const </arglist>
+      <arglist>(const double *joint_values, Eigen::Isometry3d &amp;transf) const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
       <type>virtual void</type>
       <name>computeVariablePositions</name>
       <anchorfile>classmoveit_1_1core_1_1PrismaticJointModel.html</anchorfile>
       <anchor>af566c05a3dbf63dabb39a9c267b91688</anchor>
-      <arglist>(const Eigen::Affine3d &amp;transf, double *joint_values) const </arglist>
+      <arglist>(const Eigen::Isometry3d &amp;transf, double *joint_values) const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
       <type>virtual double</type>
@@ -15745,14 +15745,14 @@
       <name>computeTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RevoluteJointModel.html</anchorfile>
       <anchor>a402a1f54f2ef8812b77ec453218cf92d</anchor>
-      <arglist>(const double *joint_values, Eigen::Affine3d &amp;transf) const </arglist>
+      <arglist>(const double *joint_values, Eigen::Isometry3d &amp;transf) const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
       <type>virtual void</type>
       <name>computeVariablePositions</name>
       <anchorfile>classmoveit_1_1core_1_1RevoluteJointModel.html</anchorfile>
       <anchor>a47e4251b8cbde0ba307b13cb0295b8f8</anchor>
-      <arglist>(const Eigen::Affine3d &amp;transf, double *joint_values) const </arglist>
+      <arglist>(const Eigen::Isometry3d &amp;transf, double *joint_values) const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
       <type>virtual double</type>
@@ -16407,7 +16407,7 @@
       <name>computeFixedTransforms</name>
       <anchorfile>classmoveit_1_1core_1_1RobotModel.html</anchorfile>
       <anchor>a7779dbc5c3d0cf3cde31583032524e84</anchor>
-      <arglist>(const LinkModel *link, const Eigen::Affine3d &amp;transform, LinkTransformMap &amp;associated_transforms)</arglist>
+      <arglist>(const LinkModel *link, const Eigen::Isometry3d &amp;transform, LinkTransformMap &amp;associated_transforms)</arglist>
     </member>
     <member kind="function" protection="protected">
       <type>JointModel *</type>
@@ -17002,14 +17002,14 @@
       <arglist>(std::vector&lt; double &gt; &amp;aabb)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getFrameTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>af7482d79ce5b29e0b7b97d0f7f187af4</anchor>
       <arglist>(const std::string &amp;id)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getFrameTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>ab04e7315202498cbb916403087785bb5</anchor>
@@ -17139,7 +17139,7 @@
       <name>printTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>af0f3e487de8c1ae809c044990b353841</anchor>
-      <arglist>(const Eigen::Affine3d &amp;transform, std::ostream &amp;out=std::cout) const </arglist>
+      <arglist>(const Eigen::Isometry3d &amp;transform, std::ostream &amp;out=std::cout) const </arglist>
     </member>
     <member kind="function">
       <type>void</type>
@@ -17531,14 +17531,14 @@
       <name>setJointPositions</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a6f29e39d4b1bad50ac078e595abaaf9c</anchor>
-      <arglist>(const std::string &amp;joint_name, const Eigen::Affine3d &amp;transform)</arglist>
+      <arglist>(const std::string &amp;joint_name, const Eigen::Isometry3d &amp;transform)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
       <name>setJointPositions</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>acf6603873541f8cf04476b95d43a4d5b</anchor>
-      <arglist>(const JointModel *joint, const Eigen::Affine3d &amp;transform)</arglist>
+      <arglist>(const JointModel *joint, const Eigen::Isometry3d &amp;transform)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
@@ -17944,94 +17944,94 @@
       <name>updateStateWithLinkAt</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a6cc3a80dbf59387597d65505623bb78e</anchor>
-      <arglist>(const std::string &amp;link_name, const Eigen::Affine3d &amp;transform, bool backward=false)</arglist>
+      <arglist>(const std::string &amp;link_name, const Eigen::Isometry3d &amp;transform, bool backward=false)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
       <name>updateStateWithLinkAt</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a43bb5bb7db541e93f0102b9f290603ff</anchor>
-      <arglist>(const LinkModel *link, const Eigen::Affine3d &amp;transform, bool backward=false)</arglist>
+      <arglist>(const LinkModel *link, const Eigen::Isometry3d &amp;transform, bool backward=false)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getGlobalLinkTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a038dc6e7063fbc24cfb3d10d8bbb880d</anchor>
       <arglist>(const std::string &amp;link_name)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getGlobalLinkTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a76797b5f33b8449dcadf17c825a6ba4c</anchor>
       <arglist>(const LinkModel *link)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getCollisionBodyTransforms</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>af104f914b69a3703349ae3f2fd9404bc</anchor>
       <arglist>(const std::string &amp;link_name, std::size_t index)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getCollisionBodyTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a8858380ce3a1c053fc0f8adbd40ea3ac</anchor>
       <arglist>(const LinkModel *link, std::size_t index)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getJointTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>ae5001e9c5b7c22d5c8e300f7f8f81a70</anchor>
       <arglist>(const std::string &amp;joint_name)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getJointTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a34aa4cffea8cb555cc1e8b5d9fa11be4</anchor>
       <arglist>(const JointModel *joint)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getGlobalLinkTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>ada011a4a3bbe1b207c8119ec534a1e23</anchor>
       <arglist>(const std::string &amp;link_name) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getGlobalLinkTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>ae0c9931c1790f0de60073ca4e56ab4cc</anchor>
       <arglist>(const LinkModel *link) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getCollisionBodyTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>ad0fbac4e2e2fc18c9341da9e271cf2cf</anchor>
       <arglist>(const std::string &amp;link_name, std::size_t index) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getCollisionBodyTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a4aa8c6a9a798141c5cebf7134c7df74c</anchor>
       <arglist>(const LinkModel *link, std::size_t index) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getJointTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>aea443160079811f45fcc9eafcabbf5b2</anchor>
       <arglist>(const std::string &amp;joint_name) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getJointTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>aabbd41a28a1a7698fd34190d9d180e50</anchor>
@@ -18217,14 +18217,14 @@
       <name>attachBody</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a6204f7ad66163fa73f713d4897c25a77</anchor>
-      <arglist>(const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Affine3d &amp;attach_trans, const std::set&lt; std::string &gt; &amp;touch_links, const std::string &amp;link_name, const trajectory_msgs::JointTrajectory &amp;detach_posture=trajectory_msgs::JointTrajectory())</arglist>
+      <arglist>(const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Isometry3d &amp;attach_trans, const std::set&lt; std::string &gt; &amp;touch_links, const std::string &amp;link_name, const trajectory_msgs::JointTrajectory &amp;detach_posture=trajectory_msgs::JointTrajectory())</arglist>
     </member>
     <member kind="function">
       <type>void</type>
       <name>attachBody</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a9fd2ac241124639ed77b16a995774725</anchor>
-      <arglist>(const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Affine3d &amp;attach_trans, const std::vector&lt; std::string &gt; &amp;touch_links, const std::string &amp;link_name, const trajectory_msgs::JointTrajectory &amp;detach_posture=trajectory_msgs::JointTrajectory())</arglist>
+      <arglist>(const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Isometry3d &amp;attach_trans, const std::vector&lt; std::string &gt; &amp;touch_links, const std::string &amp;link_name, const trajectory_msgs::JointTrajectory &amp;detach_posture=trajectory_msgs::JointTrajectory())</arglist>
     </member>
     <member kind="function">
       <type>void</type>
@@ -18458,14 +18458,14 @@
       <arglist></arglist>
     </member>
     <member kind="variable" protection="private">
-      <type>Eigen::Affine3d *</type>
+      <type>Eigen::Isometry3d *</type>
       <name>global_collision_body_transforms_</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a9a1b84afe76b0eb6bcf49e8a95b7951c</anchor>
       <arglist></arglist>
     </member>
     <member kind="variable" protection="private">
-      <type>Eigen::Affine3d *</type>
+      <type>Eigen::Isometry3d *</type>
       <name>global_link_transforms_</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a963901d995f1ad657966f02873fb43fe</anchor>
@@ -18521,7 +18521,7 @@
       <arglist></arglist>
     </member>
     <member kind="variable" protection="private">
-      <type>Eigen::Affine3d *</type>
+      <type>Eigen::Isometry3d *</type>
       <name>variable_joint_transforms_</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>ad46e590ed2595f6b3855ad5e780df810</anchor>
@@ -18896,14 +18896,14 @@
       <name>setJointPositions</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a6f29e39d4b1bad50ac078e595abaaf9c</anchor>
-      <arglist>(const std::string &amp;joint_name, const Eigen::Affine3d &amp;transform)</arglist>
+      <arglist>(const std::string &amp;joint_name, const Eigen::Isometry3d &amp;transform)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
       <name>setJointPositions</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>acf6603873541f8cf04476b95d43a4d5b</anchor>
-      <arglist>(const JointModel *joint, const Eigen::Affine3d &amp;transform)</arglist>
+      <arglist>(const JointModel *joint, const Eigen::Isometry3d &amp;transform)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
@@ -19232,14 +19232,14 @@
       <name>setToIKSolverFrame</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a08aa8a30c5c40476f44397a9d32a9e3d</anchor>
-      <arglist>(Eigen::Affine3d &amp;pose, const kinematics::KinematicsBaseConstPtr &amp;solver)</arglist>
+      <arglist>(Eigen::Isometry3d &amp;pose, const kinematics::KinematicsBaseConstPtr &amp;solver)</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
       <name>setToIKSolverFrame</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>aa591f09030389fff10bd4dfd4cf5ac23</anchor>
-      <arglist>(Eigen::Affine3d &amp;pose, const std::string &amp;ik_frame)</arglist>
+      <arglist>(Eigen::Isometry3d &amp;pose, const std::string &amp;ik_frame)</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
@@ -19260,42 +19260,42 @@
       <name>setFromIK</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>adbb7fa25dedf3b5e324786d9165b0d92</anchor>
-      <arglist>(const JointModelGroup *group, const Eigen::Affine3d &amp;pose, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
+      <arglist>(const JointModelGroup *group, const Eigen::Isometry3d &amp;pose, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
       <name>setFromIK</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a38943d2703ea1ec7b18b7f01a05d0d7b</anchor>
-      <arglist>(const JointModelGroup *group, const Eigen::Affine3d &amp;pose, const std::string &amp;tip, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
+      <arglist>(const JointModelGroup *group, const Eigen::Isometry3d &amp;pose, const std::string &amp;tip, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
       <name>setFromIK</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a7dab73858059bedb7894cf4ec520c10d</anchor>
-      <arglist>(const JointModelGroup *group, const Eigen::Affine3d &amp;pose, const std::string &amp;tip, const std::vector&lt; double &gt; &amp;consistency_limits, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
+      <arglist>(const JointModelGroup *group, const Eigen::Isometry3d &amp;pose, const std::string &amp;tip, const std::vector&lt; double &gt; &amp;consistency_limits, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
       <name>setFromIK</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>abdf85ad8c682ebc14536e5f7648c5041</anchor>
-      <arglist>(const JointModelGroup *group, const EigenSTL::vector_Affine3d &amp;poses, const std::vector&lt; std::string &gt; &amp;tips, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
+      <arglist>(const JointModelGroup *group, const EigenSTL::vector_Isometry3d &amp;poses, const std::vector&lt; std::string &gt; &amp;tips, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
       <name>setFromIK</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a9631fb6403a8afab862bd1aa52959cdc</anchor>
-      <arglist>(const JointModelGroup *group, const EigenSTL::vector_Affine3d &amp;poses, const std::vector&lt; std::string &gt; &amp;tips, const std::vector&lt; std::vector&lt; double &gt; &gt; &amp;consistency_limits, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
+      <arglist>(const JointModelGroup *group, const EigenSTL::vector_Isometry3d &amp;poses, const std::vector&lt; std::string &gt; &amp;tips, const std::vector&lt; std::vector&lt; double &gt; &gt; &amp;consistency_limits, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
       <name>setFromIKSubgroups</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>aa3479b58416de8ea77b7f5125a546629</anchor>
-      <arglist>(const JointModelGroup *group, const EigenSTL::vector_Affine3d &amp;poses, const std::vector&lt; std::string &gt; &amp;tips, const std::vector&lt; std::vector&lt; double &gt; &gt; &amp;consistency_limits, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
+      <arglist>(const JointModelGroup *group, const EigenSTL::vector_Isometry3d &amp;poses, const std::vector&lt; std::string &gt; &amp;tips, const std::vector&lt; std::vector&lt; double &gt; &gt; &amp;consistency_limits, unsigned int attempts=0, double timeout=0.0, const GroupStateValidityCallbackFn &amp;constraint=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
@@ -19327,25 +19327,25 @@
       <type>double</type>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a991d3e3273968b7e932b80bd7ec6226f</anchor>
-      <arglist>(const JointModelGroup *group, std::vector&lt; RobotStatePtr &gt; &amp;traj, const LinkModel *link, const Eigen::Affine3d &amp;target, bool global_reference_frame, const MaxEEFStep &amp;max_step, const JumpThreshold &amp;jump_threshold, const GroupStateValidityCallbackFn &amp;validCallback=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
+      <arglist>(const JointModelGroup *group, std::vector&lt; RobotStatePtr &gt; &amp;traj, const LinkModel *link, const Eigen::Isometry3d &amp;target, bool global_reference_frame, const MaxEEFStep &amp;max_step, const JumpThreshold &amp;jump_threshold, const GroupStateValidityCallbackFn &amp;validCallback=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
     </member>
     <member kind="function">
       <type>double</type>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>afda9ff554c1d5c92c7585ee9c87cc20c</anchor>
-      <arglist>(const JointModelGroup *group, std::vector&lt; RobotStatePtr &gt; &amp;traj, const LinkModel *link, const Eigen::Affine3d &amp;target, bool global_reference_frame, double max_step, double jump_threshold_factor, const GroupStateValidityCallbackFn &amp;validCallback=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
+      <arglist>(const JointModelGroup *group, std::vector&lt; RobotStatePtr &gt; &amp;traj, const LinkModel *link, const Eigen::Isometry3d &amp;target, bool global_reference_frame, double max_step, double jump_threshold_factor, const GroupStateValidityCallbackFn &amp;validCallback=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
     </member>
     <member kind="function">
       <type>double</type>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a25f69a60feea6bfc8f695b42b52db447</anchor>
-      <arglist>(const JointModelGroup *group, std::vector&lt; RobotStatePtr &gt; &amp;traj, const LinkModel *link, const EigenSTL::vector_Affine3d &amp;waypoints, bool global_reference_frame, const MaxEEFStep &amp;max_step, const JumpThreshold &amp;jump_threshold, const GroupStateValidityCallbackFn &amp;validCallback=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
+      <arglist>(const JointModelGroup *group, std::vector&lt; RobotStatePtr &gt; &amp;traj, const LinkModel *link, const EigenSTL::vector_Isometry3d &amp;waypoints, bool global_reference_frame, const MaxEEFStep &amp;max_step, const JumpThreshold &amp;jump_threshold, const GroupStateValidityCallbackFn &amp;validCallback=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
     </member>
     <member kind="function">
       <type>double</type>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>aaa0993dd42573c9aafd67c04ae1efa6a</anchor>
-      <arglist>(const JointModelGroup *group, std::vector&lt; RobotStatePtr &gt; &amp;traj, const LinkModel *link, const EigenSTL::vector_Affine3d &amp;waypoints, bool global_reference_frame, double max_step, double jump_threshold_factor, const GroupStateValidityCallbackFn &amp;validCallback=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
+      <arglist>(const JointModelGroup *group, std::vector&lt; RobotStatePtr &gt; &amp;traj, const LinkModel *link, const EigenSTL::vector_Isometry3d &amp;waypoints, bool global_reference_frame, double max_step, double jump_threshold_factor, const GroupStateValidityCallbackFn &amp;validCallback=GroupStateValidityCallbackFn(), const kinematics::KinematicsQueryOptions &amp;options=kinematics::KinematicsQueryOptions())</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
@@ -19499,94 +19499,94 @@
       <name>updateStateWithLinkAt</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a6cc3a80dbf59387597d65505623bb78e</anchor>
-      <arglist>(const std::string &amp;link_name, const Eigen::Affine3d &amp;transform, bool backward=false)</arglist>
+      <arglist>(const std::string &amp;link_name, const Eigen::Isometry3d &amp;transform, bool backward=false)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
       <name>updateStateWithLinkAt</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a43bb5bb7db541e93f0102b9f290603ff</anchor>
-      <arglist>(const LinkModel *link, const Eigen::Affine3d &amp;transform, bool backward=false)</arglist>
+      <arglist>(const LinkModel *link, const Eigen::Isometry3d &amp;transform, bool backward=false)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getGlobalLinkTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a038dc6e7063fbc24cfb3d10d8bbb880d</anchor>
       <arglist>(const std::string &amp;link_name)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getGlobalLinkTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a76797b5f33b8449dcadf17c825a6ba4c</anchor>
       <arglist>(const LinkModel *link)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getCollisionBodyTransforms</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>af104f914b69a3703349ae3f2fd9404bc</anchor>
       <arglist>(const std::string &amp;link_name, std::size_t index)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getCollisionBodyTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a8858380ce3a1c053fc0f8adbd40ea3ac</anchor>
       <arglist>(const LinkModel *link, std::size_t index)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getJointTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>ae5001e9c5b7c22d5c8e300f7f8f81a70</anchor>
       <arglist>(const std::string &amp;joint_name)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getJointTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a34aa4cffea8cb555cc1e8b5d9fa11be4</anchor>
       <arglist>(const JointModel *joint)</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getGlobalLinkTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>ada011a4a3bbe1b207c8119ec534a1e23</anchor>
       <arglist>(const std::string &amp;link_name) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getGlobalLinkTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>ae0c9931c1790f0de60073ca4e56ab4cc</anchor>
       <arglist>(const LinkModel *link) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getCollisionBodyTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>ad0fbac4e2e2fc18c9341da9e271cf2cf</anchor>
       <arglist>(const std::string &amp;link_name, std::size_t index) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getCollisionBodyTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a4aa8c6a9a798141c5cebf7134c7df74c</anchor>
       <arglist>(const LinkModel *link, std::size_t index) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getJointTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>aea443160079811f45fcc9eafcabbf5b2</anchor>
       <arglist>(const std::string &amp;joint_name) const </arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getJointTransform</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>aabbd41a28a1a7698fd34190d9d180e50</anchor>
@@ -19772,14 +19772,14 @@
       <name>attachBody</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a6204f7ad66163fa73f713d4897c25a77</anchor>
-      <arglist>(const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Affine3d &amp;attach_trans, const std::set&lt; std::string &gt; &amp;touch_links, const std::string &amp;link_name, const trajectory_msgs::JointTrajectory &amp;detach_posture=trajectory_msgs::JointTrajectory())</arglist>
+      <arglist>(const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Isometry3d &amp;attach_trans, const std::set&lt; std::string &gt; &amp;touch_links, const std::string &amp;link_name, const trajectory_msgs::JointTrajectory &amp;detach_posture=trajectory_msgs::JointTrajectory())</arglist>
     </member>
     <member kind="function">
       <type>void</type>
       <name>attachBody</name>
       <anchorfile>classmoveit_1_1core_1_1RobotState.html</anchorfile>
       <anchor>a9fd2ac241124639ed77b16a995774725</anchor>
-      <arglist>(const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Affine3d &amp;attach_trans, const std::vector&lt; std::string &gt; &amp;touch_links, const std::string &amp;link_name, const trajectory_msgs::JointTrajectory &amp;detach_posture=trajectory_msgs::JointTrajectory())</arglist>
+      <arglist>(const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Isometry3d &amp;attach_trans, const std::vector&lt; std::string &gt; &amp;touch_links, const std::string &amp;link_name, const trajectory_msgs::JointTrajectory &amp;detach_posture=trajectory_msgs::JointTrajectory())</arglist>
     </member>
     <member kind="function">
       <type>void</type>
@@ -20162,7 +20162,7 @@
       <arglist>(const std::string &amp;from_frame) const override</arglist>
     </member>
     <member kind="function">
-      <type>const Eigen::Affine3d &amp;</type>
+      <type>const Eigen::Isometry3d &amp;</type>
       <name>getTransform</name>
       <anchorfile>classplanning__scene_1_1SceneTransforms.html</anchorfile>
       <anchor>ab6bc4674267a8a2749192344eda8cb42</anchor>
@@ -20522,7 +20522,7 @@
       <arglist>() const </arglist>
     </member>
     <member kind="function" virtualness="virtual">
-      <type>virtual const Eigen::Affine3d &amp;</type>
+      <type>virtual const Eigen::Isometry3d &amp;</type>
       <name>getTransform</name>
       <anchorfile>classmoveit_1_1core_1_1Transforms.html</anchorfile>
       <anchor>a567bf07ed01be1293e2488c89fcad6db</anchor>
@@ -20568,7 +20568,7 @@
       <name>setTransform</name>
       <anchorfile>classmoveit_1_1core_1_1Transforms.html</anchorfile>
       <anchor>aec6167704b561dbc69c21fc2dee08424</anchor>
-      <arglist>(const Eigen::Affine3d &amp;t, const std::string &amp;from_frame)</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;t, const std::string &amp;from_frame)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
@@ -20617,7 +20617,7 @@
       <name>transformPose</name>
       <anchorfile>classmoveit_1_1core_1_1Transforms.html</anchorfile>
       <anchor>a84bf991a795b2185e387a5a00466e75d</anchor>
-      <arglist>(const std::string &amp;from_frame, const Eigen::Affine3d &amp;t_in, Eigen::Affine3d &amp;t_out) const </arglist>
+      <arglist>(const std::string &amp;from_frame, const Eigen::Isometry3d &amp;t_in, Eigen::Isometry3d &amp;t_out) const </arglist>
     </member>
     <member kind="function" static="yes">
       <type>static bool</type>
@@ -20659,7 +20659,7 @@
       <name>setTransform</name>
       <anchorfile>classmoveit_1_1core_1_1Transforms.html</anchorfile>
       <anchor>aec6167704b561dbc69c21fc2dee08424</anchor>
-      <arglist>(const Eigen::Affine3d &amp;t, const std::string &amp;from_frame)</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;t, const std::string &amp;from_frame)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
@@ -20708,7 +20708,7 @@
       <name>transformPose</name>
       <anchorfile>classmoveit_1_1core_1_1Transforms.html</anchorfile>
       <anchor>a84bf991a795b2185e387a5a00466e75d</anchor>
-      <arglist>(const std::string &amp;from_frame, const Eigen::Affine3d &amp;t_in, Eigen::Affine3d &amp;t_out) const </arglist>
+      <arglist>(const std::string &amp;from_frame, const Eigen::Isometry3d &amp;t_in, Eigen::Isometry3d &amp;t_out) const </arglist>
     </member>
   </compound>
   <compound kind="class">
@@ -20977,7 +20977,7 @@
       <arglist></arglist>
     </member>
     <member kind="variable" protection="protected">
-      <type>Eigen::Affine3d</type>
+      <type>Eigen::Isometry3d</type>
       <name>sensor_pose_</name>
       <anchorfile>classkinematic__constraints_1_1VisibilityConstraint.html</anchorfile>
       <anchor>a62b2e41044f09df70135880e49f1058e</anchor>
@@ -20998,7 +20998,7 @@
       <arglist></arglist>
     </member>
     <member kind="variable" protection="protected">
-      <type>Eigen::Affine3d</type>
+      <type>Eigen::Isometry3d</type>
       <name>target_pose_</name>
       <anchorfile>classkinematic__constraints_1_1VisibilityConstraint.html</anchorfile>
       <anchor>adaaa2616266617afc7f247eb454e0ec7</anchor>
@@ -21707,14 +21707,14 @@
       <name>addToObject</name>
       <anchorfile>classcollision__detection_1_1World.html</anchorfile>
       <anchor>a1d13f3b6bf0ddb5bafb360ef9ea10814</anchor>
-      <arglist>(const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Affine3d &amp;poses)</arglist>
+      <arglist>(const std::string &amp;id, const std::vector&lt; shapes::ShapeConstPtr &gt; &amp;shapes, const EigenSTL::vector_Isometry3d &amp;poses)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
       <name>addToObject</name>
       <anchorfile>classcollision__detection_1_1World.html</anchorfile>
       <anchor>a289081085766dc32e07b602438572c16</anchor>
-      <arglist>(const std::string &amp;id, const shapes::ShapeConstPtr &amp;shape, const Eigen::Affine3d &amp;pose)</arglist>
+      <arglist>(const std::string &amp;id, const shapes::ShapeConstPtr &amp;shape, const Eigen::Isometry3d &amp;pose)</arglist>
     </member>
     <member kind="function">
       <type>const_iterator</type>
@@ -21777,14 +21777,14 @@
       <name>moveObject</name>
       <anchorfile>classcollision__detection_1_1World.html</anchorfile>
       <anchor>aabf55427d7f6ea0911b32285a2f40dc1</anchor>
-      <arglist>(const std::string &amp;id, const Eigen::Affine3d &amp;transform)</arglist>
+      <arglist>(const std::string &amp;id, const Eigen::Isometry3d &amp;transform)</arglist>
     </member>
     <member kind="function">
       <type>bool</type>
       <name>moveShapeInObject</name>
       <anchorfile>classcollision__detection_1_1World.html</anchorfile>
       <anchor>a671b1507b6ffea4a478b2c903fd667e8</anchor>
-      <arglist>(const std::string &amp;id, const shapes::ShapeConstPtr &amp;shape, const Eigen::Affine3d &amp;pose)</arglist>
+      <arglist>(const std::string &amp;id, const shapes::ShapeConstPtr &amp;shape, const Eigen::Isometry3d &amp;pose)</arglist>
     </member>
     <member kind="function">
       <type>void</type>
@@ -21847,7 +21847,7 @@
       <name>addToObjectInternal</name>
       <anchorfile>classcollision__detection_1_1World.html</anchorfile>
       <anchor>a76904d0cf2e97f475d3917bcc6007f9c</anchor>
-      <arglist>(const ObjectPtr &amp;obj, const shapes::ShapeConstPtr &amp;shape, const Eigen::Affine3d &amp;pose)</arglist>
+      <arglist>(const ObjectPtr &amp;obj, const shapes::ShapeConstPtr &amp;shape, const Eigen::Isometry3d &amp;pose)</arglist>
     </member>
     <member kind="function" protection="private">
       <type>void</type>
@@ -22357,14 +22357,14 @@
       <name>transform2fcl</name>
       <anchorfile>namespacecollision__detection.html</anchorfile>
       <anchor>ac62f07a0d167ce0255db6ab31b9506bb</anchor>
-      <arglist>(const Eigen::Affine3d &amp;b, fcl::Transform3f &amp;f)</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;b, fcl::Transform3f &amp;f)</arglist>
     </member>
     <member kind="function">
       <type>fcl::Transform3f</type>
       <name>transform2fcl</name>
       <anchorfile>namespacecollision__detection.html</anchorfile>
       <anchor>a65033c779e897cf789d2be527fc26be2</anchor>
-      <arglist>(const Eigen::Affine3d &amp;b)</arglist>
+      <arglist>(const Eigen::Isometry3d &amp;b)</arglist>
     </member>
   </compound>
   <compound kind="namespace">
@@ -22941,7 +22941,7 @@
       <arglist></arglist>
     </member>
     <member kind="typedef">
-      <type>std::map&lt; std::string, Eigen::Affine3d, std::less&lt; std::string &gt;, Eigen::aligned_allocator&lt; std::pair&lt; const std::string, Eigen::Affine3d &gt; &gt; &gt;</type>
+      <type>std::map&lt; std::string, Eigen::Isometry3d, std::less&lt; std::string &gt;, Eigen::aligned_allocator&lt; std::pair&lt; const std::string, Eigen::Isometry3d &gt; &gt; &gt;</type>
       <name>FixedTransformsMap</name>
       <anchorfile>namespacemoveit_1_1core.html</anchorfile>
       <anchor>aab2e7121788a9fdfc2ca8ad2fc2f78a2</anchor>
@@ -23004,7 +23004,7 @@
       <arglist></arglist>
     </member>
     <member kind="typedef">
-      <type>std::map&lt; const LinkModel *, Eigen::Affine3d, std::less&lt; const LinkModel * &gt;, Eigen::aligned_allocator&lt; std::pair&lt; const LinkModel *const, Eigen::Affine3d &gt; &gt; &gt;</type>
+      <type>std::map&lt; const LinkModel *, Eigen::Isometry3d, std::less&lt; const LinkModel * &gt;, Eigen::aligned_allocator&lt; std::pair&lt; const LinkModel *const, Eigen::Isometry3d &gt; &gt; &gt;</type>
       <name>LinkTransformMap</name>
       <anchorfile>namespacemoveit_1_1core.html</anchorfile>
       <anchor>a4586cb570da059f7f173b6fd9f358917</anchor>

--- a/robowflex_library/include/robowflex_library/adapter.h
+++ b/robowflex_library/include/robowflex_library/adapter.h
@@ -1,0 +1,20 @@
+/* Author: Zachary Kingston */
+
+#ifndef ROBOWFLEX_ADAPTER_
+#define ROBOWFLEX_ADAPTER_
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <robowflex_library/macros.h>
+
+namespace robowflex
+{
+#if ROBOWFLEX_MOVEIT_ISOMETRY
+    using RobotPose = Eigen::Isometry3d;
+#else
+    using RobotPose = Eigen::Affine3d;
+#endif
+}  // namespace robowflex
+
+#endif

--- a/robowflex_library/include/robowflex_library/builder.h
+++ b/robowflex_library/include/robowflex_library/builder.h
@@ -76,7 +76,7 @@ namespace robowflex
          *  \param[in] tolerances XYZ Euler angle tolerances about orientation.
          */
         void setGoalRegion(const std::string &ee_name, const std::string &base_name,
-                           const Eigen::Affine3d &pose, const GeometryConstPtr &geometry,
+                           const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry,
                            const Eigen::Quaterniond &orientation, const Eigen::Vector3d &tolerances);
 
         /** \brief Tiles some \a geometry around a \a pose in \a base_name for the end-effector \a ee_name.
@@ -93,9 +93,9 @@ namespace robowflex
          *  \param[in] n Number of rotations (evenly divided around the circle).
          */
         void addGoalRotaryTile(const std::string &ee_name, const std::string &base_name,
-                               const Eigen::Affine3d &pose, const GeometryConstPtr &geometry,
+                               const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry,
                                const Eigen::Quaterniond &orientation, const Eigen::Vector3d &tolerances,
-                               const Eigen::Affine3d &offset, const Eigen::Vector3d &axis, unsigned int n);
+                               const Eigen::Isometry3d &offset, const Eigen::Vector3d &axis, unsigned int n);
 
         /** \brief Adds a set of regions to grasp a cylinder from the side. This function assumes the X-axis
          * of the end-effector frame \a ee_name points "forward" for grasping.
@@ -108,7 +108,7 @@ namespace robowflex
          *  \param[in] n The number of regions to create.
          */
         void addCylinderSideGrasp(const std::string &ee_name, const std::string &base_name,
-                                  const Eigen::Affine3d &pose, const GeometryConstPtr &cylinder,
+                                  const Eigen::Isometry3d &pose, const GeometryConstPtr &cylinder,
                                   double distance, double depth, unsigned int n);
 
         /** \brief Clears all goals.
@@ -131,7 +131,7 @@ namespace robowflex
          *  \param[in] tolerances XYZ Euler angle tolerances about orientation.
          */
         void addPathPoseConstraint(const std::string &ee_name, const std::string &base_name,
-                                   const Eigen::Affine3d &pose, const GeometryConstPtr &geometry,
+                                   const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry,
                                    const Eigen::Quaterniond &orientation, const Eigen::Vector3d &tolerances);
 
         /** \brief Set a position constraint on the path.
@@ -142,7 +142,7 @@ namespace robowflex
          *  \param[in] geometry The geometry describing the position constraint.
          */
         void addPathPositionConstraint(const std::string &ee_name, const std::string &base_name,
-                                       const Eigen::Affine3d &pose, const GeometryConstPtr &geometry);
+                                       const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry);
 
         /** \brief Set an orientation constraint on the path.
          *  Sets the orientation constraint from \a orientation and XYZ Euler angle tolerances \a tolerances.

--- a/robowflex_library/include/robowflex_library/builder.h
+++ b/robowflex_library/include/robowflex_library/builder.h
@@ -6,6 +6,7 @@
 #include <moveit/planning_pipeline/planning_pipeline.h>
 
 #include <robowflex_library/class_forward.h>
+#include <robowflex_library/adapter.h>
 
 namespace robowflex
 {
@@ -76,7 +77,7 @@ namespace robowflex
          *  \param[in] tolerances XYZ Euler angle tolerances about orientation.
          */
         void setGoalRegion(const std::string &ee_name, const std::string &base_name,
-                           const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry,
+                           const RobotPose &pose, const GeometryConstPtr &geometry,
                            const Eigen::Quaterniond &orientation, const Eigen::Vector3d &tolerances);
 
         /** \brief Tiles some \a geometry around a \a pose in \a base_name for the end-effector \a ee_name.
@@ -93,9 +94,9 @@ namespace robowflex
          *  \param[in] n Number of rotations (evenly divided around the circle).
          */
         void addGoalRotaryTile(const std::string &ee_name, const std::string &base_name,
-                               const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry,
+                               const RobotPose &pose, const GeometryConstPtr &geometry,
                                const Eigen::Quaterniond &orientation, const Eigen::Vector3d &tolerances,
-                               const Eigen::Isometry3d &offset, const Eigen::Vector3d &axis, unsigned int n);
+                               const RobotPose &offset, const Eigen::Vector3d &axis, unsigned int n);
 
         /** \brief Adds a set of regions to grasp a cylinder from the side. This function assumes the X-axis
          * of the end-effector frame \a ee_name points "forward" for grasping.
@@ -108,7 +109,7 @@ namespace robowflex
          *  \param[in] n The number of regions to create.
          */
         void addCylinderSideGrasp(const std::string &ee_name, const std::string &base_name,
-                                  const Eigen::Isometry3d &pose, const GeometryConstPtr &cylinder,
+                                  const RobotPose &pose, const GeometryConstPtr &cylinder,
                                   double distance, double depth, unsigned int n);
 
         /** \brief Clears all goals.
@@ -131,7 +132,7 @@ namespace robowflex
          *  \param[in] tolerances XYZ Euler angle tolerances about orientation.
          */
         void addPathPoseConstraint(const std::string &ee_name, const std::string &base_name,
-                                   const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry,
+                                   const RobotPose &pose, const GeometryConstPtr &geometry,
                                    const Eigen::Quaterniond &orientation, const Eigen::Vector3d &tolerances);
 
         /** \brief Set a position constraint on the path.
@@ -142,7 +143,7 @@ namespace robowflex
          *  \param[in] geometry The geometry describing the position constraint.
          */
         void addPathPositionConstraint(const std::string &ee_name, const std::string &base_name,
-                                       const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry);
+                                       const RobotPose &pose, const GeometryConstPtr &geometry);
 
         /** \brief Set an orientation constraint on the path.
          *  Sets the orientation constraint from \a orientation and XYZ Euler angle tolerances \a tolerances.

--- a/robowflex_library/include/robowflex_library/io/visualization.h
+++ b/robowflex_library/include/robowflex_library/io/visualization.h
@@ -79,7 +79,7 @@ namespace robowflex
              *  \param[in] color Color of the marker.
              */
             void addGeometryMarker(const std::string &name, const GeometryConstPtr &geometry,
-                                   const std::string &base_frame, const Eigen::Affine3d &pose,
+                                   const std::string &base_frame, const Eigen::Isometry3d &pose,
                                    const Eigen::Vector4d &color = {0.2, 0.3, 0.7, 1.0});
 
             /** \brief Adds an arrow marker to the managed list of markers. Displayed after an updateMarkers()
@@ -91,7 +91,7 @@ namespace robowflex
              *  \param[in] scale The scale of the marker.
              */
             void addArrowMarker(const std::string &name, const std::string &base_frame,
-                                const Eigen::Affine3d &pose, const Eigen::Vector4d &color,
+                                const Eigen::Isometry3d &pose, const Eigen::Vector4d &color,
                                 const Eigen::Vector3d &scale);
 
             /** \brief Adds a text marker to the managed list of markers. Displayed after updateMarkers().
@@ -103,7 +103,7 @@ namespace robowflex
              *  \param[in] color Color of the marker.
              */
             void addTextMarker(const std::string &name, const std::string &text,
-                               const std::string &base_frame, const Eigen::Affine3d &pose, double height,
+                               const std::string &base_frame, const Eigen::Isometry3d &pose, double height,
                                const Eigen::Vector4d &color = {1, 1, 1, 1});
 
             /** \brief Adds the current goal of the motion request builder as a
@@ -135,7 +135,7 @@ namespace robowflex
              *  \param[in] scale The scale of the marker.
              */
             void fillMarker(visualization_msgs::Marker &marker, const std::string &base_frame,
-                            const Eigen::Affine3d &pose, const Eigen::Vector4d &color,
+                            const Eigen::Isometry3d &pose, const Eigen::Vector4d &color,
                             const Eigen::Vector3d &scale) const;
 
             RobotConstPtr robot_;            ///< Robot being visualized.

--- a/robowflex_library/include/robowflex_library/io/visualization.h
+++ b/robowflex_library/include/robowflex_library/io/visualization.h
@@ -79,7 +79,7 @@ namespace robowflex
              *  \param[in] color Color of the marker.
              */
             void addGeometryMarker(const std::string &name, const GeometryConstPtr &geometry,
-                                   const std::string &base_frame, const Eigen::Isometry3d &pose,
+                                   const std::string &base_frame, const RobotPose &pose,
                                    const Eigen::Vector4d &color = {0.2, 0.3, 0.7, 1.0});
 
             /** \brief Adds an arrow marker to the managed list of markers. Displayed after an updateMarkers()
@@ -91,7 +91,7 @@ namespace robowflex
              *  \param[in] scale The scale of the marker.
              */
             void addArrowMarker(const std::string &name, const std::string &base_frame,
-                                const Eigen::Isometry3d &pose, const Eigen::Vector4d &color,
+                                const RobotPose &pose, const Eigen::Vector4d &color,
                                 const Eigen::Vector3d &scale);
 
             /** \brief Adds a text marker to the managed list of markers. Displayed after updateMarkers().
@@ -103,7 +103,7 @@ namespace robowflex
              *  \param[in] color Color of the marker.
              */
             void addTextMarker(const std::string &name, const std::string &text,
-                               const std::string &base_frame, const Eigen::Isometry3d &pose, double height,
+                               const std::string &base_frame, const RobotPose &pose, double height,
                                const Eigen::Vector4d &color = {1, 1, 1, 1});
 
             /** \brief Adds the current goal of the motion request builder as a
@@ -135,7 +135,7 @@ namespace robowflex
              *  \param[in] scale The scale of the marker.
              */
             void fillMarker(visualization_msgs::Marker &marker, const std::string &base_frame,
-                            const Eigen::Isometry3d &pose, const Eigen::Vector4d &color,
+                            const RobotPose &pose, const Eigen::Vector4d &color,
                             const Eigen::Vector3d &scale) const;
 
             RobotConstPtr robot_;            ///< Robot being visualized.

--- a/robowflex_library/include/robowflex_library/macros.h
+++ b/robowflex_library/include/robowflex_library/macros.h
@@ -5,6 +5,8 @@
 
 #include <boost/version.hpp>  // for boost version macros
 
+#include <moveit/version.h>  // for MoveIt version macros
+
 #include <ros/common.h>  // for ROS version macros
 
 /** \file */
@@ -34,6 +36,13 @@
 #else
 #define ROBOWFLEX_YAML_FLOW(n)
 #endif
+
+
+///
+/// MoveIt Version Checking
+
+/** \brief Tests if this MoveIt version is Melodic or higher */
+#define ROBOWFLEX_MOVEIT_MELODIC MOVEIT_MINOR_VERSION >= 10
 
 ///
 /// Compiler Warning Helpers

--- a/robowflex_library/include/robowflex_library/macros.h
+++ b/robowflex_library/include/robowflex_library/macros.h
@@ -40,9 +40,13 @@
 
 ///
 /// MoveIt Version Checking
+///
 
-/** \brief Tests if this MoveIt version is Melodic or higher */
-#define ROBOWFLEX_MOVEIT_MELODIC MOVEIT_MINOR_VERSION >= 10
+/** \brief Phrase MoveIt version as integer. */
+#define ROBOWFLEX_MOVEIT_VERSION ((MOVEIT_VERSION_MAJOR * 100000u) + (MOVEIT_VERSION_MINOR * 1000u) + (MOVEIT_VERSION_PATCH * 1u))
+
+/** \brief Tests if this MoveIt version is Melodic or higher. */
+#define ROBOWFLEX_MOVEIT_ISOMETRY (ROBOWFLEX_MOVEIT_VERSION >= 0010006)
 
 ///
 /// Compiler Warning Helpers

--- a/robowflex_library/include/robowflex_library/robot.h
+++ b/robowflex_library/include/robowflex_library/robot.h
@@ -260,8 +260,9 @@ namespace robowflex
          *  \param[in] tolerances Tolerance about \a orientation.
          *  \return True on success, false on failure.
          */
-        bool setFromIK(const std::string &group, const GeometryConstPtr &region, const Eigen::Affine3d &pose,
-                       const Eigen::Quaterniond &orientation, const Eigen::Vector3d &tolerances);
+        bool setFromIK(const std::string &group, const GeometryConstPtr &region,
+                       const Eigen::Isometry3d &pose, const Eigen::Quaterniond &orientation,
+                       const Eigen::Vector3d &tolerances);
 
         /** \brief Gets the current joint positions of the scratch state.
          *  \return A vector of joint positions.
@@ -277,14 +278,14 @@ namespace robowflex
          *  \param[in] name The name of the link to find the transform of.
          *  \return The transform of link \a name.
          */
-        const Eigen::Affine3d &getLinkTF(const std::string &name) const;
+        const Eigen::Isometry3d &getLinkTF(const std::string &name) const;
 
         /** \brief Get the current pose of a link \a target in the frame of \a base.
          *  \param[in] base The link to use as the base frame.
          *  \param[in] target The link to find the transform of.
          *  \return The transform of link \a target in the frame of \a base.
          */
-        const Eigen::Affine3d getRelativeLinkTF(const std::string &base, const std::string &target) const;
+        const Eigen::Isometry3d getRelativeLinkTF(const std::string &base, const std::string &target) const;
 
         /** \} */
 

--- a/robowflex_library/include/robowflex_library/robot.h
+++ b/robowflex_library/include/robowflex_library/robot.h
@@ -20,6 +20,7 @@
 #include <moveit/robot_model_loader/robot_model_loader.h>
 
 #include <robowflex_library/class_forward.h>
+#include <robowflex_library/adapter.h>
 #include <robowflex_library/io/handler.h>
 
 namespace robowflex
@@ -261,7 +262,7 @@ namespace robowflex
          *  \return True on success, false on failure.
          */
         bool setFromIK(const std::string &group, const GeometryConstPtr &region,
-                       const Eigen::Isometry3d &pose, const Eigen::Quaterniond &orientation,
+                       const RobotPose &pose, const Eigen::Quaterniond &orientation,
                        const Eigen::Vector3d &tolerances);
 
         /** \brief Gets the current joint positions of the scratch state.
@@ -278,14 +279,14 @@ namespace robowflex
          *  \param[in] name The name of the link to find the transform of.
          *  \return The transform of link \a name.
          */
-        const Eigen::Isometry3d &getLinkTF(const std::string &name) const;
+        const RobotPose &getLinkTF(const std::string &name) const;
 
         /** \brief Get the current pose of a link \a target in the frame of \a base.
          *  \param[in] base The link to use as the base frame.
          *  \param[in] target The link to find the transform of.
          *  \return The transform of link \a target in the frame of \a base.
          */
-        const Eigen::Isometry3d getRelativeLinkTF(const std::string &base, const std::string &target) const;
+        const RobotPose getRelativeLinkTF(const std::string &base, const std::string &target) const;
 
         /** \} */
 

--- a/robowflex_library/include/robowflex_library/robowflex.h
+++ b/robowflex_library/include/robowflex_library/robowflex.h
@@ -12,6 +12,7 @@ namespace robowflex
 }
 
 #include <robowflex_library/class_forward.h>
+#include <robowflex_library/adapter.h>
 #include <robowflex_library/macros.h>
 #include <robowflex_library/util.h>
 #include <robowflex_library/yaml.h>

--- a/robowflex_library/include/robowflex_library/scene.h
+++ b/robowflex_library/include/robowflex_library/scene.h
@@ -104,7 +104,7 @@ namespace robowflex
          *  \param[in] pose Pose of object.
          */
         void updateCollisionObject(const std::string &name, const GeometryConstPtr &geometry,
-                                   const Eigen::Affine3d &pose);
+                                   const Eigen::Isometry3d &pose);
 
         /** \brief Removes an object from the planning scene.
          *  \param[in] name Name of object to remove.
@@ -115,14 +115,14 @@ namespace robowflex
          *  \param[in] name Name of object to get pose for.
          *  \return Pose of the object.
          */
-        Eigen::Affine3d getObjectPose(const std::string &name);
+        Eigen::Isometry3d getObjectPose(const std::string &name);
 
         /** \brief Get the pose of a particular frame in the scene.
          *  Example, use this to get the pose from /world to /base_link.
          *  \param[in] id The ID of the frame to look for.
          *  \return Pose of the object, Identity if frame is not present.
          */
-        Eigen::Affine3d getFramePose(const std::string &id) const;
+        Eigen::Isometry3d getFramePose(const std::string &id) const;
 
         /** \brief Attempts to set the collision detector plugin used by the scene to \a name.
          *  In MoveIt by default, 'Hybrid' is the only plugin defined.

--- a/robowflex_library/include/robowflex_library/scene.h
+++ b/robowflex_library/include/robowflex_library/scene.h
@@ -15,6 +15,7 @@
 #include <moveit/robot_state/robot_state.h>               // for robot_state::RobotState
 
 #include <robowflex_library/class_forward.h>
+#include <robowflex_library/adapter.h>
 
 namespace robowflex
 {
@@ -104,7 +105,7 @@ namespace robowflex
          *  \param[in] pose Pose of object.
          */
         void updateCollisionObject(const std::string &name, const GeometryConstPtr &geometry,
-                                   const Eigen::Isometry3d &pose);
+                                   const RobotPose &pose);
 
         /** \brief Removes an object from the planning scene.
          *  \param[in] name Name of object to remove.
@@ -115,14 +116,14 @@ namespace robowflex
          *  \param[in] name Name of object to get pose for.
          *  \return Pose of the object.
          */
-        Eigen::Isometry3d getObjectPose(const std::string &name);
+        RobotPose getObjectPose(const std::string &name);
 
         /** \brief Get the pose of a particular frame in the scene.
          *  Example, use this to get the pose from /world to /base_link.
          *  \param[in] id The ID of the frame to look for.
          *  \return Pose of the object, Identity if frame is not present.
          */
-        Eigen::Isometry3d getFramePose(const std::string &id) const;
+        RobotPose getFramePose(const std::string &id) const;
 
         /** \brief Attempts to set the collision detector plugin used by the scene to \a name.
          *  In MoveIt by default, 'Hybrid' is the only plugin defined.

--- a/robowflex_library/include/robowflex_library/tf.h
+++ b/robowflex_library/include/robowflex_library/tf.h
@@ -15,6 +15,7 @@
 #include <moveit_msgs/OrientationConstraint.h>
 
 #include <robowflex_library/class_forward.h>
+#include <robowflex_library/adapter.h>
 
 namespace robowflex
 {
@@ -38,17 +39,17 @@ namespace robowflex
          */
         geometry_msgs::Vector3 vectorEigenToMsg(const Eigen::Vector3d &vector);
 
-        /** \brief Converts a pose message to Eigen::Isometry3d.
+        /** \brief Converts a pose message to RobotPose.
          *  \param[in] msg Message to convert.
-         *  \return \a msg an Eigen::Isometry3d.
+         *  \return \a msg an RobotPose.
          */
-        Eigen::Isometry3d poseMsgToEigen(const geometry_msgs::Pose &msg);
+        RobotPose poseMsgToEigen(const geometry_msgs::Pose &msg);
 
-        /** \brief Converts an Eigen::Isometry3d to a pose message.
+        /** \brief Converts an RobotPose to a pose message.
          *  \param[in] pose Pose to convert.
          *  \return \a pose as a pose message.
          */
-        geometry_msgs::Pose poseEigenToMsg(const Eigen::Isometry3d &pose);
+        geometry_msgs::Pose poseEigenToMsg(const RobotPose &pose);
 
         /** \brief Converts a quaternion message to Eigen::Quaterniond.
          *  \param[in] msg Message to convert.
@@ -67,7 +68,7 @@ namespace robowflex
          *  \param[in] geometry Geometry to get bounding volume for.
          *  \return Bounding volume message for \a geometry at \a pose.
          */
-        moveit_msgs::BoundingVolume getBoundingVolume(const Eigen::Isometry3d &pose,
+        moveit_msgs::BoundingVolume getBoundingVolume(const RobotPose &pose,
                                                       const GeometryConstPtr &geometry);
 
         /** \brief Get a position constraint message.
@@ -78,7 +79,7 @@ namespace robowflex
          */
         moveit_msgs::PositionConstraint getPositionConstraint(const std::string &ee_name,
                                                               const std::string &base_name,
-                                                              const Eigen::Isometry3d &pose,
+                                                              const RobotPose &pose,
                                                               const GeometryConstPtr &geometry);
 
         /** \brief Get an orientation constraint message.

--- a/robowflex_library/include/robowflex_library/tf.h
+++ b/robowflex_library/include/robowflex_library/tf.h
@@ -38,17 +38,17 @@ namespace robowflex
          */
         geometry_msgs::Vector3 vectorEigenToMsg(const Eigen::Vector3d &vector);
 
-        /** \brief Converts a pose message to Eigen::Affine3d.
+        /** \brief Converts a pose message to Eigen::Isometry3d.
          *  \param[in] msg Message to convert.
-         *  \return \a msg an Eigen::Affine3d.
+         *  \return \a msg an Eigen::Isometry3d.
          */
-        Eigen::Affine3d poseMsgToEigen(const geometry_msgs::Pose &msg);
+        Eigen::Isometry3d poseMsgToEigen(const geometry_msgs::Pose &msg);
 
-        /** \brief Converts an Eigen::Affine3d to a pose message.
+        /** \brief Converts an Eigen::Isometry3d to a pose message.
          *  \param[in] pose Pose to convert.
          *  \return \a pose as a pose message.
          */
-        geometry_msgs::Pose poseEigenToMsg(const Eigen::Affine3d &pose);
+        geometry_msgs::Pose poseEigenToMsg(const Eigen::Isometry3d &pose);
 
         /** \brief Converts a quaternion message to Eigen::Quaterniond.
          *  \param[in] msg Message to convert.
@@ -67,7 +67,7 @@ namespace robowflex
          *  \param[in] geometry Geometry to get bounding volume for.
          *  \return Bounding volume message for \a geometry at \a pose.
          */
-        moveit_msgs::BoundingVolume getBoundingVolume(const Eigen::Affine3d &pose,
+        moveit_msgs::BoundingVolume getBoundingVolume(const Eigen::Isometry3d &pose,
                                                       const GeometryConstPtr &geometry);
 
         /** \brief Get a position constraint message.
@@ -78,7 +78,7 @@ namespace robowflex
          */
         moveit_msgs::PositionConstraint getPositionConstraint(const std::string &ee_name,
                                                               const std::string &base_name,
-                                                              const Eigen::Affine3d &pose,
+                                                              const Eigen::Isometry3d &pose,
                                                               const GeometryConstPtr &geometry);
 
         /** \brief Get an orientation constraint message.

--- a/robowflex_library/scripts/r2_test.cpp
+++ b/robowflex_library/scripts/r2_test.cpp
@@ -96,9 +96,9 @@ int planAndBuild()
     Eigen::Vector3d tolerance_feet(0.01, 0.01, 0.01);
     Eigen::Vector3d tolerance_waist(0.005, 0.005, 0.005);
     // Set a goal region to plan to.
-    request.setGoalRegion(                                                                        //
-        right_foot, world,                                                                        //
-        Eigen::Affine3d(Eigen::Translation3d(1.26, -0.248, -1.104)), Geometry::makeSphere(0.1),  //
+    request.setGoalRegion(                                                                         //
+        right_foot, world,                                                                         //
+        Eigen::Isometry3d(Eigen::Translation3d(1.26, -0.248, -1.104)), Geometry::makeSphere(0.1),  //
         Eigen::Quaterniond(0, 0, 1, 0), Eigen::Vector3d{0.01, 0.01, 0.01});
 
     // Set a pose constraint on the left foot (keep fixed throughout the path).

--- a/robowflex_library/scripts/r2_test.cpp
+++ b/robowflex_library/scripts/r2_test.cpp
@@ -98,7 +98,7 @@ int planAndBuild()
     // Set a goal region to plan to.
     request.setGoalRegion(                                                                         //
         right_foot, world,                                                                         //
-        Eigen::Isometry3d(Eigen::Translation3d(1.26, -0.248, -1.104)), Geometry::makeSphere(0.1),  //
+        RobotPose(Eigen::Translation3d(1.26, -0.248, -1.104)), Geometry::makeSphere(0.1),  //
         Eigen::Quaterniond(0, 0, 1, 0), Eigen::Vector3d{0.01, 0.01, 0.01});
 
     // Set a pose constraint on the left foot (keep fixed throughout the path).

--- a/robowflex_library/scripts/ur5_benchmark.cpp
+++ b/robowflex_library/scripts/ur5_benchmark.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
     MotionRequestBuilderPtr pose_request(new MotionRequestBuilder(planner, "manipulator"));
     pose_request->setStartConfiguration({0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
 
-    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+    RobotPose pose = RobotPose::Identity();
     pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
     Eigen::Quaterniond orn{0, 0, 1, 0};
 

--- a/robowflex_library/scripts/ur5_benchmark.cpp
+++ b/robowflex_library/scripts/ur5_benchmark.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
     MotionRequestBuilderPtr pose_request(new MotionRequestBuilder(planner, "manipulator"));
     pose_request->setStartConfiguration({0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
 
-    Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
     pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
     Eigen::Quaterniond orn{0, 0, 1, 0};
 

--- a/robowflex_library/scripts/ur5_cylinder.cpp
+++ b/robowflex_library/scripts/ur5_cylinder.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
     std::cin.get();
 
     // Create the cylinder we want to grasp
-    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+    RobotPose pose = RobotPose::Identity();
     pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
 
     auto cylinder = Geometry::makeCylinder(0.025, 0.1);

--- a/robowflex_library/scripts/ur5_cylinder.cpp
+++ b/robowflex_library/scripts/ur5_cylinder.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
     std::cin.get();
 
     // Create the cylinder we want to grasp
-    Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
     pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
 
     auto cylinder = Geometry::makeCylinder(0.025, 0.1);

--- a/robowflex_library/scripts/ur5_pool.cpp
+++ b/robowflex_library/scripts/ur5_pool.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
     MotionRequestBuilder request(planner, "manipulator");
     request.setStartConfiguration({0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
 
-    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+    RobotPose pose = RobotPose::Identity();
     pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
     Eigen::Quaterniond orn{0, 0, 1, 0};
 

--- a/robowflex_library/scripts/ur5_pool.cpp
+++ b/robowflex_library/scripts/ur5_pool.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
     MotionRequestBuilder request(planner, "manipulator");
     request.setStartConfiguration({0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
 
-    Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
     pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
     Eigen::Quaterniond orn{0, 0, 1, 0};
 

--- a/robowflex_library/scripts/ur5_test.cpp
+++ b/robowflex_library/scripts/ur5_test.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
         MotionRequestBuilder request(planner, "manipulator");
         request.setStartConfiguration({0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
 
-        Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+        RobotPose pose = RobotPose::Identity();
         pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
         Eigen::Quaterniond orn{0, 0, 1, 0};
 

--- a/robowflex_library/scripts/ur5_test.cpp
+++ b/robowflex_library/scripts/ur5_test.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
         MotionRequestBuilder request(planner, "manipulator");
         request.setStartConfiguration({0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
 
-        Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+        Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
         pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
         Eigen::Quaterniond orn{0, 0, 1, 0};
 

--- a/robowflex_library/scripts/ur5_visualization.cpp
+++ b/robowflex_library/scripts/ur5_visualization.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
     MotionRequestBuilder request(planner, "manipulator");
     request.setStartConfiguration({0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
 
-    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+    RobotPose pose = RobotPose::Identity();
     pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
     Eigen::Quaterniond orn{0, 0, 1, 0};
 

--- a/robowflex_library/scripts/ur5_visualization.cpp
+++ b/robowflex_library/scripts/ur5_visualization.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
     MotionRequestBuilder request(planner, "manipulator");
     request.setStartConfiguration({0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
 
-    Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
     pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
     Eigen::Quaterniond orn{0, 0, 1, 0};
 

--- a/robowflex_library/src/builder.cpp
+++ b/robowflex_library/src/builder.cpp
@@ -98,7 +98,7 @@ void MotionRequestBuilder::setGoalConfiguration(const robot_state::RobotStatePtr
 }
 
 void MotionRequestBuilder::setGoalRegion(const std::string &ee_name, const std::string &base_name,
-                                         const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry,
+                                         const RobotPose &pose, const GeometryConstPtr &geometry,
                                          const Eigen::Quaterniond &orientation,
                                          const Eigen::Vector3d &tolerances)
 {
@@ -112,9 +112,9 @@ void MotionRequestBuilder::setGoalRegion(const std::string &ee_name, const std::
 }
 
 void MotionRequestBuilder::addGoalRotaryTile(const std::string &ee_name, const std::string &base_name,
-                                             const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry,
+                                             const RobotPose &pose, const GeometryConstPtr &geometry,
                                              const Eigen::Quaterniond &orientation,
-                                             const Eigen::Vector3d &tolerances, const Eigen::Isometry3d &offset,
+                                             const Eigen::Vector3d &tolerances, const RobotPose &offset,
                                              const Eigen::Vector3d &axis, unsigned int n)
 {
     double pi2 = 2 * boost::math::constants::pi<double>();
@@ -122,7 +122,7 @@ void MotionRequestBuilder::addGoalRotaryTile(const std::string &ee_name, const s
     for (double angle = 0; angle < pi2; angle += pi2 / n)
     {
         Eigen::Quaterniond rotation(Eigen::AngleAxisd(angle, axis));
-        Eigen::Isometry3d newPose = pose * rotation * offset;
+        RobotPose newPose = pose * rotation * offset;
         Eigen::Quaterniond newOrientation(rotation * orientation);
 
         setGoalRegion(ee_name, base_name, newPose, geometry, newOrientation, tolerances);
@@ -130,12 +130,12 @@ void MotionRequestBuilder::addGoalRotaryTile(const std::string &ee_name, const s
 }
 
 void MotionRequestBuilder::addCylinderSideGrasp(const std::string &ee_name, const std::string &base_name,
-                                                const Eigen::Isometry3d &pose, const GeometryConstPtr &cylinder,
+                                                const RobotPose &pose, const GeometryConstPtr &cylinder,
                                                 double distance, double depth, unsigned int n)
 {
     // Grasping region to tile
     auto box = Geometry::makeBox(depth, depth, cylinder->getDimensions()[1]);
-    Eigen::Isometry3d offset(Eigen::Translation3d(cylinder->getDimensions()[0] + distance, 0, 0));
+    RobotPose offset(Eigen::Translation3d(cylinder->getDimensions()[0] + distance, 0, 0));
 
     Eigen::Quaterniond orientation =
         Eigen::AngleAxisd(-boost::math::constants::pi<double>(), Eigen::Vector3d::UnitX())  //
@@ -158,7 +158,7 @@ void MotionRequestBuilder::setAllowedPlanningTime(double allowed_planning_time)
 }
 
 void MotionRequestBuilder::addPathPoseConstraint(const std::string &ee_name, const std::string &base_name,
-                                                 const Eigen::Isometry3d &pose,
+                                                 const RobotPose &pose,
                                                  const GeometryConstPtr &geometry,
                                                  const Eigen::Quaterniond &orientation,
                                                  const Eigen::Vector3d &tolerances)
@@ -168,7 +168,7 @@ void MotionRequestBuilder::addPathPoseConstraint(const std::string &ee_name, con
 }
 
 void MotionRequestBuilder::addPathPositionConstraint(const std::string &ee_name, const std::string &base_name,
-                                                     const Eigen::Isometry3d &pose,
+                                                     const RobotPose &pose,
                                                      const GeometryConstPtr &geometry)
 {
     request_.path_constraints.position_constraints.push_back(

--- a/robowflex_library/src/builder.cpp
+++ b/robowflex_library/src/builder.cpp
@@ -98,7 +98,7 @@ void MotionRequestBuilder::setGoalConfiguration(const robot_state::RobotStatePtr
 }
 
 void MotionRequestBuilder::setGoalRegion(const std::string &ee_name, const std::string &base_name,
-                                         const Eigen::Affine3d &pose, const GeometryConstPtr &geometry,
+                                         const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry,
                                          const Eigen::Quaterniond &orientation,
                                          const Eigen::Vector3d &tolerances)
 {
@@ -112,9 +112,9 @@ void MotionRequestBuilder::setGoalRegion(const std::string &ee_name, const std::
 }
 
 void MotionRequestBuilder::addGoalRotaryTile(const std::string &ee_name, const std::string &base_name,
-                                             const Eigen::Affine3d &pose, const GeometryConstPtr &geometry,
+                                             const Eigen::Isometry3d &pose, const GeometryConstPtr &geometry,
                                              const Eigen::Quaterniond &orientation,
-                                             const Eigen::Vector3d &tolerances, const Eigen::Affine3d &offset,
+                                             const Eigen::Vector3d &tolerances, const Eigen::Isometry3d &offset,
                                              const Eigen::Vector3d &axis, unsigned int n)
 {
     double pi2 = 2 * boost::math::constants::pi<double>();
@@ -122,7 +122,7 @@ void MotionRequestBuilder::addGoalRotaryTile(const std::string &ee_name, const s
     for (double angle = 0; angle < pi2; angle += pi2 / n)
     {
         Eigen::Quaterniond rotation(Eigen::AngleAxisd(angle, axis));
-        Eigen::Affine3d newPose = pose * rotation * offset;
+        Eigen::Isometry3d newPose = pose * rotation * offset;
         Eigen::Quaterniond newOrientation(rotation * orientation);
 
         setGoalRegion(ee_name, base_name, newPose, geometry, newOrientation, tolerances);
@@ -130,12 +130,12 @@ void MotionRequestBuilder::addGoalRotaryTile(const std::string &ee_name, const s
 }
 
 void MotionRequestBuilder::addCylinderSideGrasp(const std::string &ee_name, const std::string &base_name,
-                                                const Eigen::Affine3d &pose, const GeometryConstPtr &cylinder,
+                                                const Eigen::Isometry3d &pose, const GeometryConstPtr &cylinder,
                                                 double distance, double depth, unsigned int n)
 {
     // Grasping region to tile
     auto box = Geometry::makeBox(depth, depth, cylinder->getDimensions()[1]);
-    Eigen::Affine3d offset(Eigen::Translation3d(cylinder->getDimensions()[0] + distance, 0, 0));
+    Eigen::Isometry3d offset(Eigen::Translation3d(cylinder->getDimensions()[0] + distance, 0, 0));
 
     Eigen::Quaterniond orientation =
         Eigen::AngleAxisd(-boost::math::constants::pi<double>(), Eigen::Vector3d::UnitX())  //
@@ -158,7 +158,7 @@ void MotionRequestBuilder::setAllowedPlanningTime(double allowed_planning_time)
 }
 
 void MotionRequestBuilder::addPathPoseConstraint(const std::string &ee_name, const std::string &base_name,
-                                                 const Eigen::Affine3d &pose,
+                                                 const Eigen::Isometry3d &pose,
                                                  const GeometryConstPtr &geometry,
                                                  const Eigen::Quaterniond &orientation,
                                                  const Eigen::Vector3d &tolerances)
@@ -168,7 +168,7 @@ void MotionRequestBuilder::addPathPoseConstraint(const std::string &ee_name, con
 }
 
 void MotionRequestBuilder::addPathPositionConstraint(const std::string &ee_name, const std::string &base_name,
-                                                     const Eigen::Affine3d &pose,
+                                                     const Eigen::Isometry3d &pose,
                                                      const GeometryConstPtr &geometry)
 {
     request_.path_constraints.position_constraints.push_back(

--- a/robowflex_library/src/detail/fetch.cpp
+++ b/robowflex_library/src/detail/fetch.cpp
@@ -44,9 +44,9 @@ bool FetchRobot::addVirtualJointSRDF(tinyxml2::XMLDocument &doc)
 
 void FetchRobot::pointHead(const Eigen::Vector3d &point)
 {
-    const Eigen::Isometry3d point_pose = Eigen::Isometry3d(Eigen::Translation3d(point));
-    const Eigen::Isometry3d point_pan = getLinkTF("head_pan_link").inverse() * point_pose;
-    const Eigen::Isometry3d point_tilt = getLinkTF("head_tilt_link").inverse() * point_pose;
+    const RobotPose point_pose = RobotPose(Eigen::Translation3d(point));
+    const RobotPose point_pan = getLinkTF("head_pan_link").inverse() * point_pose;
+    const RobotPose point_tilt = getLinkTF("head_tilt_link").inverse() * point_pose;
 
     const double pan = atan2(point_pan.translation().y(), point_pan.translation().x());
     const double tilt = -atan2(point_tilt.translation().z(),

--- a/robowflex_library/src/detail/fetch.cpp
+++ b/robowflex_library/src/detail/fetch.cpp
@@ -44,9 +44,9 @@ bool FetchRobot::addVirtualJointSRDF(tinyxml2::XMLDocument &doc)
 
 void FetchRobot::pointHead(const Eigen::Vector3d &point)
 {
-    const Eigen::Affine3d point_pose = Eigen::Affine3d(Eigen::Translation3d(point));
-    const Eigen::Affine3d point_pan = getLinkTF("head_pan_link").inverse() * point_pose;
-    const Eigen::Affine3d point_tilt = getLinkTF("head_tilt_link").inverse() * point_pose;
+    const Eigen::Isometry3d point_pose = Eigen::Isometry3d(Eigen::Translation3d(point));
+    const Eigen::Isometry3d point_pan = getLinkTF("head_pan_link").inverse() * point_pose;
+    const Eigen::Isometry3d point_tilt = getLinkTF("head_tilt_link").inverse() * point_pose;
 
     const double pan = atan2(point_pan.translation().y(), point_pan.translation().x());
     const double tilt = -atan2(point_tilt.translation().z(),

--- a/robowflex_library/src/io/visualization.cpp
+++ b/robowflex_library/src/io/visualization.cpp
@@ -99,7 +99,7 @@ void IO::RVIZHelper::updateTrajectories(const std::vector<planning_interface::Mo
 }
 
 void IO::RVIZHelper::fillMarker(visualization_msgs::Marker &marker, const std::string &base_frame,
-                                const Eigen::Isometry3d &pose, const Eigen::Vector4d &color,
+                                const RobotPose &pose, const Eigen::Vector4d &color,
                                 const Eigen::Vector3d &scale) const
 {
     marker.header.frame_id = base_frame;
@@ -120,7 +120,7 @@ void IO::RVIZHelper::fillMarker(visualization_msgs::Marker &marker, const std::s
 }
 
 void IO::RVIZHelper::addArrowMarker(const std::string &name, const std::string &base_frame,
-                                    const Eigen::Isometry3d &pose, const Eigen::Vector4d &color,
+                                    const RobotPose &pose, const Eigen::Vector4d &color,
                                     const Eigen::Vector3d &scale)
 {
     visualization_msgs::Marker marker;
@@ -132,7 +132,7 @@ void IO::RVIZHelper::addArrowMarker(const std::string &name, const std::string &
 }
 
 void IO::RVIZHelper::addTextMarker(const std::string &name, const std::string &text,
-                                   const std::string &base_frame, const Eigen::Isometry3d &pose, double height,
+                                   const std::string &base_frame, const RobotPose &pose, double height,
                                    const Eigen::Vector4d &color)
 {
     visualization_msgs::Marker marker;
@@ -145,7 +145,7 @@ void IO::RVIZHelper::addTextMarker(const std::string &name, const std::string &t
 }
 
 void IO::RVIZHelper::addGeometryMarker(const std::string &name, const GeometryConstPtr &geometry,
-                                       const std::string &base_frame, const Eigen::Isometry3d &pose,
+                                       const std::string &base_frame, const RobotPose &pose,
                                        const Eigen::Vector4d &color)
 {
     visualization_msgs::Marker marker;
@@ -199,7 +199,7 @@ void IO::RVIZHelper::addGoalMarker(const std::string &name, const MotionRequestB
             const auto &pname = pg.link_name;
 
             // Get global transform of position constraint
-            Eigen::Isometry3d pose = robot_->getLinkTF(pg.header.frame_id);
+            RobotPose pose = robot_->getLinkTF(pg.header.frame_id);
             pose.translate(TF::vectorMsgToEigen(pg.target_point_offset));
 
             // Iterate over all position primitives and their poses
@@ -226,7 +226,7 @@ void IO::RVIZHelper::addGoalMarker(const std::string &name, const MotionRequestB
                     auto q = TF::quaternionMsgToEigen(og.orientation);
 
                     // Arrow display frame.
-                    Eigen::Isometry3d qframe = Eigen::Isometry3d::Identity();
+                    RobotPose qframe = RobotPose::Identity();
                     qframe.translate(frame.translation()); // Place arrows at the origin of the position volume
 
                     Eigen::Vector3d scale = {0.1, 0.008, 0.003};  // A nice default size of arrow
@@ -279,7 +279,7 @@ void IO::RVIZHelper::addMarker(float x, float y, float z)
     visualization_msgs::Marker marker;
     const std::string &base_frame = "map";
 
-    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+    RobotPose pose = RobotPose::Identity();
     pose *= Eigen::Translation3d(x, y, z);
 
     Eigen::Vector3d scale = {0.5, 0.5, 0.5};

--- a/robowflex_library/src/io/visualization.cpp
+++ b/robowflex_library/src/io/visualization.cpp
@@ -99,7 +99,7 @@ void IO::RVIZHelper::updateTrajectories(const std::vector<planning_interface::Mo
 }
 
 void IO::RVIZHelper::fillMarker(visualization_msgs::Marker &marker, const std::string &base_frame,
-                                const Eigen::Affine3d &pose, const Eigen::Vector4d &color,
+                                const Eigen::Isometry3d &pose, const Eigen::Vector4d &color,
                                 const Eigen::Vector3d &scale) const
 {
     marker.header.frame_id = base_frame;
@@ -120,7 +120,7 @@ void IO::RVIZHelper::fillMarker(visualization_msgs::Marker &marker, const std::s
 }
 
 void IO::RVIZHelper::addArrowMarker(const std::string &name, const std::string &base_frame,
-                                    const Eigen::Affine3d &pose, const Eigen::Vector4d &color,
+                                    const Eigen::Isometry3d &pose, const Eigen::Vector4d &color,
                                     const Eigen::Vector3d &scale)
 {
     visualization_msgs::Marker marker;
@@ -132,7 +132,7 @@ void IO::RVIZHelper::addArrowMarker(const std::string &name, const std::string &
 }
 
 void IO::RVIZHelper::addTextMarker(const std::string &name, const std::string &text,
-                                   const std::string &base_frame, const Eigen::Affine3d &pose, double height,
+                                   const std::string &base_frame, const Eigen::Isometry3d &pose, double height,
                                    const Eigen::Vector4d &color)
 {
     visualization_msgs::Marker marker;
@@ -145,7 +145,7 @@ void IO::RVIZHelper::addTextMarker(const std::string &name, const std::string &t
 }
 
 void IO::RVIZHelper::addGeometryMarker(const std::string &name, const GeometryConstPtr &geometry,
-                                       const std::string &base_frame, const Eigen::Affine3d &pose,
+                                       const std::string &base_frame, const Eigen::Isometry3d &pose,
                                        const Eigen::Vector4d &color)
 {
     visualization_msgs::Marker marker;
@@ -199,7 +199,7 @@ void IO::RVIZHelper::addGoalMarker(const std::string &name, const MotionRequestB
             const auto &pname = pg.link_name;
 
             // Get global transform of position constraint
-            Eigen::Affine3d pose = robot_->getLinkTF(pg.header.frame_id);
+            Eigen::Isometry3d pose = robot_->getLinkTF(pg.header.frame_id);
             pose.translate(TF::vectorMsgToEigen(pg.target_point_offset));
 
             // Iterate over all position primitives and their poses
@@ -226,7 +226,7 @@ void IO::RVIZHelper::addGoalMarker(const std::string &name, const MotionRequestB
                     auto q = TF::quaternionMsgToEigen(og.orientation);
 
                     // Arrow display frame.
-                    Eigen::Affine3d qframe = Eigen::Affine3d::Identity();
+                    Eigen::Isometry3d qframe = Eigen::Isometry3d::Identity();
                     qframe.translate(frame.translation()); // Place arrows at the origin of the position volume
 
                     Eigen::Vector3d scale = {0.1, 0.008, 0.003};  // A nice default size of arrow
@@ -279,7 +279,7 @@ void IO::RVIZHelper::addMarker(float x, float y, float z)
     visualization_msgs::Marker marker;
     const std::string &base_frame = "map";
 
-    Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
     pose *= Eigen::Translation3d(x, y, z);
 
     Eigen::Vector3d scale = {0.5, 0.5, 0.5};

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -310,10 +310,10 @@ std::vector<std::string> Robot::getJointNames() const
 }
 
 bool Robot::setFromIK(const std::string &group,                                       //
-                      const GeometryConstPtr &region, const Eigen::Isometry3d &pose,  //
+                      const GeometryConstPtr &region, const RobotPose &pose,  //
                       const Eigen::Quaterniond &orientation, const Eigen::Vector3d &tolerances)
 {
-    Eigen::Isometry3d sampled_pose = pose;
+    RobotPose sampled_pose = pose;
     auto sample = region->sample();
     if (!sample.first)
         return false;
@@ -333,12 +333,12 @@ bool Robot::setFromIK(const std::string &group,                                 
     return false;
 }
 
-const Eigen::Isometry3d &Robot::getLinkTF(const std::string &name) const
+const RobotPose &Robot::getLinkTF(const std::string &name) const
 {
     return scratch_->getGlobalLinkTransform(name);
 }
 
-const Eigen::Isometry3d Robot::getRelativeLinkTF(const std::string &base, const std::string &target) const
+const RobotPose Robot::getRelativeLinkTF(const std::string &base, const std::string &target) const
 {
     auto base_tf = scratch_->getGlobalLinkTransform(base);
     auto target_tf = scratch_->getGlobalLinkTransform(target);
@@ -457,7 +457,7 @@ namespace
         return node;
     }
 
-    Eigen::Isometry3d urdfPoseToEigen(const urdf::Pose &pose)
+    RobotPose urdfPoseToEigen(const urdf::Pose &pose)
     {
         geometry_msgs::Pose msg;
         msg.position.x = pose.position.x;
@@ -560,7 +560,7 @@ bool Robot::dumpPathTransforms(const robot_trajectory::RobotTrajectory &path, co
             if (urdf_link->visual)
             {
                 const auto &link = model_->getLinkModel(link_name);
-                Eigen::Isometry3d tf =
+                RobotPose tf =
                     state->getGlobalLinkTransform(link) * urdfPoseToEigen(urdf_link->visual->origin);
                 point[link->getName()] = IO::toNode(TF::poseEigenToMsg(tf));
             }

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -309,11 +309,11 @@ std::vector<std::string> Robot::getJointNames() const
     return scratch_->getVariableNames();
 }
 
-bool Robot::setFromIK(const std::string &group,                                     //
-                      const GeometryConstPtr &region, const Eigen::Affine3d &pose,  //
+bool Robot::setFromIK(const std::string &group,                                       //
+                      const GeometryConstPtr &region, const Eigen::Isometry3d &pose,  //
                       const Eigen::Quaterniond &orientation, const Eigen::Vector3d &tolerances)
 {
-    Eigen::Affine3d sampled_pose = pose;
+    Eigen::Isometry3d sampled_pose = pose;
     auto sample = region->sample();
     if (!sample.first)
         return false;
@@ -333,12 +333,12 @@ bool Robot::setFromIK(const std::string &group,                                 
     return false;
 }
 
-const Eigen::Affine3d &Robot::getLinkTF(const std::string &name) const
+const Eigen::Isometry3d &Robot::getLinkTF(const std::string &name) const
 {
     return scratch_->getGlobalLinkTransform(name);
 }
 
-const Eigen::Affine3d Robot::getRelativeLinkTF(const std::string &base, const std::string &target) const
+const Eigen::Isometry3d Robot::getRelativeLinkTF(const std::string &base, const std::string &target) const
 {
     auto base_tf = scratch_->getGlobalLinkTransform(base);
     auto target_tf = scratch_->getGlobalLinkTransform(target);
@@ -457,7 +457,7 @@ namespace
         return node;
     }
 
-    Eigen::Affine3d urdfPoseToEigen(const urdf::Pose &pose)
+    Eigen::Isometry3d urdfPoseToEigen(const urdf::Pose &pose)
     {
         geometry_msgs::Pose msg;
         msg.position.x = pose.position.x;
@@ -560,7 +560,7 @@ bool Robot::dumpPathTransforms(const robot_trajectory::RobotTrajectory &path, co
             if (urdf_link->visual)
             {
                 const auto &link = model_->getLinkModel(link_name);
-                Eigen::Affine3d tf =
+                Eigen::Isometry3d tf =
                     state->getGlobalLinkTransform(link) * urdfPoseToEigen(urdf_link->visual->origin);
                 point[link->getName()] = IO::toNode(TF::poseEigenToMsg(tf));
             }

--- a/robowflex_library/src/scene.cpp
+++ b/robowflex_library/src/scene.cpp
@@ -135,7 +135,7 @@ void Scene::useMessage(const moveit_msgs::PlanningScene &msg, bool diff)
 }
 
 void Scene::updateCollisionObject(const std::string &name, const GeometryConstPtr &geometry,
-                                  const Eigen::Affine3d &pose)
+                                  const Eigen::Isometry3d &pose)
 {
     auto &world = scene_->getWorldNonConst();
     if (world->hasObject(name))
@@ -154,17 +154,17 @@ void Scene::removeCollisionObject(const std::string &name)
     scene_->getWorldNonConst()->removeObject(name);
 }
 
-Eigen::Affine3d Scene::getObjectPose(const std::string &name)
+Eigen::Isometry3d Scene::getObjectPose(const std::string &name)
 {
     auto &world = scene_->getWorldNonConst();
     const auto &obj = world->getObject(name);
     if (obj)
         return obj->shape_poses_[0];
 
-    return Eigen::Affine3d::Identity();
+    return Eigen::Isometry3d::Identity();
 }
 
-Eigen::Affine3d Scene::getFramePose(const std::string &id) const
+Eigen::Isometry3d Scene::getFramePose(const std::string &id) const
 {
     if (not scene_->knowsFrameTransform(id))
     {

--- a/robowflex_library/src/scene.cpp
+++ b/robowflex_library/src/scene.cpp
@@ -135,7 +135,7 @@ void Scene::useMessage(const moveit_msgs::PlanningScene &msg, bool diff)
 }
 
 void Scene::updateCollisionObject(const std::string &name, const GeometryConstPtr &geometry,
-                                  const Eigen::Isometry3d &pose)
+                                  const RobotPose &pose)
 {
     auto &world = scene_->getWorldNonConst();
     if (world->hasObject(name))
@@ -154,17 +154,17 @@ void Scene::removeCollisionObject(const std::string &name)
     scene_->getWorldNonConst()->removeObject(name);
 }
 
-Eigen::Isometry3d Scene::getObjectPose(const std::string &name)
+RobotPose Scene::getObjectPose(const std::string &name)
 {
     auto &world = scene_->getWorldNonConst();
     const auto &obj = world->getObject(name);
     if (obj)
         return obj->shape_poses_[0];
 
-    return Eigen::Isometry3d::Identity();
+    return RobotPose::Identity();
 }
 
-Eigen::Isometry3d Scene::getFramePose(const std::string &id) const
+RobotPose Scene::getFramePose(const std::string &id) const
 {
     if (not scene_->knowsFrameTransform(id))
     {

--- a/robowflex_library/src/tf.cpp
+++ b/robowflex_library/src/tf.cpp
@@ -22,14 +22,14 @@ geometry_msgs::Vector3 TF::vectorEigenToMsg(const Eigen::Vector3d &vector)
     return msg;
 }
 
-Eigen::Affine3d TF::poseMsgToEigen(const geometry_msgs::Pose &msg)
+Eigen::Isometry3d TF::poseMsgToEigen(const geometry_msgs::Pose &msg)
 {
-    Eigen::Affine3d pose;
+    Eigen::Isometry3d pose;
     tf::poseMsgToEigen(msg, pose);
     return pose;
 }
 
-geometry_msgs::Pose TF::poseEigenToMsg(const Eigen::Affine3d &pose)
+geometry_msgs::Pose TF::poseEigenToMsg(const Eigen::Isometry3d &pose)
 {
     geometry_msgs::Pose msg;
     tf::poseEigenToMsg(pose, msg);
@@ -50,7 +50,7 @@ geometry_msgs::Quaternion TF::quaternionEigenToMsg(const Eigen::Quaterniond &qua
     return msg;
 }
 
-moveit_msgs::BoundingVolume TF::getBoundingVolume(const Eigen::Affine3d &pose,
+moveit_msgs::BoundingVolume TF::getBoundingVolume(const Eigen::Isometry3d &pose,
                                                   const GeometryConstPtr &geometry)
 {
     moveit_msgs::BoundingVolume bv;
@@ -71,7 +71,7 @@ moveit_msgs::BoundingVolume TF::getBoundingVolume(const Eigen::Affine3d &pose,
 
 moveit_msgs::PositionConstraint TF::getPositionConstraint(const std::string &ee_name,
                                                           const std::string &base_name,
-                                                          const Eigen::Affine3d &pose,
+                                                          const Eigen::Isometry3d &pose,
                                                           const GeometryConstPtr &geometry)
 {
     moveit_msgs::PositionConstraint constraint;

--- a/robowflex_library/src/tf.cpp
+++ b/robowflex_library/src/tf.cpp
@@ -22,14 +22,14 @@ geometry_msgs::Vector3 TF::vectorEigenToMsg(const Eigen::Vector3d &vector)
     return msg;
 }
 
-Eigen::Isometry3d TF::poseMsgToEigen(const geometry_msgs::Pose &msg)
+RobotPose TF::poseMsgToEigen(const geometry_msgs::Pose &msg)
 {
-    Eigen::Isometry3d pose;
+    RobotPose pose;
     tf::poseMsgToEigen(msg, pose);
     return pose;
 }
 
-geometry_msgs::Pose TF::poseEigenToMsg(const Eigen::Isometry3d &pose)
+geometry_msgs::Pose TF::poseEigenToMsg(const RobotPose &pose)
 {
     geometry_msgs::Pose msg;
     tf::poseEigenToMsg(pose, msg);
@@ -50,7 +50,7 @@ geometry_msgs::Quaternion TF::quaternionEigenToMsg(const Eigen::Quaterniond &qua
     return msg;
 }
 
-moveit_msgs::BoundingVolume TF::getBoundingVolume(const Eigen::Isometry3d &pose,
+moveit_msgs::BoundingVolume TF::getBoundingVolume(const RobotPose &pose,
                                                   const GeometryConstPtr &geometry)
 {
     moveit_msgs::BoundingVolume bv;
@@ -71,7 +71,7 @@ moveit_msgs::BoundingVolume TF::getBoundingVolume(const Eigen::Isometry3d &pose,
 
 moveit_msgs::PositionConstraint TF::getPositionConstraint(const std::string &ee_name,
                                                           const std::string &base_name,
-                                                          const Eigen::Isometry3d &pose,
+                                                          const RobotPose &pose,
                                                           const GeometryConstPtr &geometry)
 {
     moveit_msgs::PositionConstraint constraint;

--- a/robowflex_ompl/scripts/ur5_ompl_interface.cpp
+++ b/robowflex_ompl/scripts/ur5_ompl_interface.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     MotionRequestBuilder request(planner, "manipulator");
     request.setStartConfiguration({0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
 
-    Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
     pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
     Eigen::Quaterniond orn{0, 0, 1, 0};
 

--- a/robowflex_ompl/scripts/ur5_ompl_interface.cpp
+++ b/robowflex_ompl/scripts/ur5_ompl_interface.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     MotionRequestBuilder request(planner, "manipulator");
     request.setStartConfiguration({0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
 
-    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+    RobotPose pose = RobotPose::Identity();
     pose.translate(Eigen::Vector3d{-0.268, -0.826, 1.313});
     Eigen::Quaterniond orn{0, 0, 1, 0};
 

--- a/tmpack/src/footstep_planner/my_graph_tester.cpp
+++ b/tmpack/src/footstep_planner/my_graph_tester.cpp
@@ -111,7 +111,7 @@ namespace robowflex
 
                 // Find the location of the stationary tip in the workspace
                 // robot.setState(joint_positions);
-                Eigen::Affine3d tip_tf = robot->getLinkTF(stationary_tip_name);
+                Eigen::Isometry3d tip_tf = robot->getLinkTF(stationary_tip_name);
                 std::cout << "left: " << robot->getLinkTF("r2/left_leg/gripper/tip").translation()
                           << std::endl;
                 std::cout << "right: " << robot->getLinkTF("r2/right_leg/gripper/tip").translation()
@@ -139,7 +139,7 @@ namespace robowflex
 
                 request->setGoalRegion(
                     moving_tip_name, "world",
-                    Eigen::Affine3d(Eigen::Translation3d(x, y, z) * Eigen::Quaterniond::Identity()),
+                    Eigen::Isometry3d(Eigen::Translation3d(x, y, z) * Eigen::Quaterniond::Identity()),
                     Geometry::makeSphere(0.01), Eigen::Quaterniond(0, 0, 1, 0), feet_tolerance);
 
                 last_foot_left = !last_foot_left;

--- a/tmpack/src/footstep_planner/my_graph_tester.cpp
+++ b/tmpack/src/footstep_planner/my_graph_tester.cpp
@@ -111,7 +111,7 @@ namespace robowflex
 
                 // Find the location of the stationary tip in the workspace
                 // robot.setState(joint_positions);
-                Eigen::Isometry3d tip_tf = robot->getLinkTF(stationary_tip_name);
+                RobotPose tip_tf = robot->getLinkTF(stationary_tip_name);
                 std::cout << "left: " << robot->getLinkTF("r2/left_leg/gripper/tip").translation()
                           << std::endl;
                 std::cout << "right: " << robot->getLinkTF("r2/right_leg/gripper/tip").translation()
@@ -139,7 +139,7 @@ namespace robowflex
 
                 request->setGoalRegion(
                     moving_tip_name, "world",
-                    Eigen::Isometry3d(Eigen::Translation3d(x, y, z) * Eigen::Quaterniond::Identity()),
+                    RobotPose(Eigen::Translation3d(x, y, z) * Eigen::Quaterniond::Identity()),
                     Geometry::makeSphere(0.01), Eigen::Quaterniond(0, 0, 1, 0), feet_tolerance);
 
                 last_foot_left = !last_foot_left;

--- a/tmpack/src/footstep_planner/my_walker.cpp
+++ b/tmpack/src/footstep_planner/my_walker.cpp
@@ -94,7 +94,7 @@ namespace robowflex
 
         // Find the location of the stationary tip in the workspace
         // robot.setState(joint_positions);
-        Eigen::Affine3d tip_tf = robot->getLinkTF(stationary_tip_name);
+        Eigen::Isometry3d tip_tf = robot->getLinkTF(stationary_tip_name);
         std::cout << "left: " << robot->getLinkTF("r2/left_leg/gripper/tip").translation() << std::endl;
         std::cout << "right: " << robot->getLinkTF("r2/right_leg/gripper/tip").translation() << std::endl;
         std::cout << "moving: " << moving_tip_name << std::endl;
@@ -119,7 +119,7 @@ namespace robowflex
 
         request->setGoalRegion(
             moving_tip_name, "world",
-            Eigen::Affine3d(Eigen::Translation3d(x, y, z) * Eigen::Quaterniond::Identity()),
+            Eigen::Isometry3d(Eigen::Translation3d(x, y, z) * Eigen::Quaterniond::Identity()),
             Geometry::makeSphere(0.01), Eigen::Quaterniond(0, 0, 1, 0), feet_tolerance);
 
         last_foot_left = !last_foot_left;

--- a/tmpack/src/footstep_planner/my_walker.cpp
+++ b/tmpack/src/footstep_planner/my_walker.cpp
@@ -94,7 +94,7 @@ namespace robowflex
 
         // Find the location of the stationary tip in the workspace
         // robot.setState(joint_positions);
-        Eigen::Isometry3d tip_tf = robot->getLinkTF(stationary_tip_name);
+        RobotPose tip_tf = robot->getLinkTF(stationary_tip_name);
         std::cout << "left: " << robot->getLinkTF("r2/left_leg/gripper/tip").translation() << std::endl;
         std::cout << "right: " << robot->getLinkTF("r2/right_leg/gripper/tip").translation() << std::endl;
         std::cout << "moving: " << moving_tip_name << std::endl;
@@ -119,7 +119,7 @@ namespace robowflex
 
         request->setGoalRegion(
             moving_tip_name, "world",
-            Eigen::Isometry3d(Eigen::Translation3d(x, y, z) * Eigen::Quaterniond::Identity()),
+            RobotPose(Eigen::Translation3d(x, y, z) * Eigen::Quaterniond::Identity()),
             Geometry::makeSphere(0.01), Eigen::Quaterniond(0, 0, 1, 0), feet_tolerance);
 
         last_foot_left = !last_foot_left;


### PR DESCRIPTION
As MoveIt! has moved to `Eigen::Isometry3d` from `Eigen::Affine3d`, so have we. But, to maintain compatibility with Kinetic & Indigo, we have a new `typedef` (or, `using`, technically), introduced in `adapter.h`, `robowflex::RobotPose`.