### PR TITLE
Use type traits rather than macros to get correct type for MoveIt transforms

### DIFF
--- a/robowflex_library/include/robowflex_library/adapter.h
+++ b/robowflex_library/include/robowflex_library/adapter.h
@@ -3,18 +3,19 @@
 #ifndef ROBOWFLEX_ADAPTER_
 #define ROBOWFLEX_ADAPTER_
 
-#include <Eigen/Core>
-#include <Eigen/Geometry>
+#include <type_traits>
 
-#include <robowflex_library/macros.h>
+#include <moveit/transforms/transforms.h>
 
 namespace robowflex
 {
-#if ROBOWFLEX_MOVEIT_ISOMETRY
-    using RobotPose = Eigen::Isometry3d;
-#else
-    using RobotPose = Eigen::Affine3d;
-#endif
+    using RobotPose = std::remove_cv<                                      //
+        std::remove_reference<                                             //
+            decltype(                                                      //
+                std::declval<moveit::core::Transforms>().getTransform("")  //
+                )                                                          //
+            >::type                                                        //
+        >::type;
 }  // namespace robowflex
 
 #endif

--- a/robowflex_library/include/robowflex_library/adapter.h
+++ b/robowflex_library/include/robowflex_library/adapter.h
@@ -9,12 +9,11 @@
 
 namespace robowflex
 {
-    using RobotPose = std::remove_cv<                                      //
-        std::remove_reference<                                             //
-            decltype(                                                      //
-                std::declval<moveit::core::Transforms>().getTransform("")  //
-                )                                                          //
-            >::type                                                        //
+    /** \brief A pose (point in SE(3)) used in various functions. Defined from what \e MoveIt! uses. */
+    using RobotPose = std::decay<                                      //
+        decltype(                                                      //
+            std::declval<moveit::core::Transforms>().getTransform("")  //
+            )                                                          //
         >::type;
 }  // namespace robowflex
 

--- a/robowflex_library/include/robowflex_library/macros.h
+++ b/robowflex_library/include/robowflex_library/macros.h
@@ -37,16 +37,18 @@
 #define ROBOWFLEX_YAML_FLOW(n)
 #endif
 
-
 ///
 /// MoveIt Version Checking
 ///
 
 /** \brief Phrase MoveIt version as integer. */
-#define ROBOWFLEX_MOVEIT_VERSION ((MOVEIT_VERSION_MAJOR * 100000u) + (MOVEIT_VERSION_MINOR * 1000u) + (MOVEIT_VERSION_PATCH * 1u))
+#define ROBOWFLEX_MOVEIT_VERSION_COMPUTE(major, minor, patch)                                                \
+    ((major * 100000u) + (minor * 1000u) + (patch * 1u))
+#define ROBOWFLEX_MOVEIT_VERSION                                                                             \
+    ROBOWFLEX_MOVEIT_VERSION_COMPUTE(MOVEIT_VERSION_MAJOR, MOVEIT_VERSION_MINOR, MOVEIT_VERSION_PATCH)
 
 /** \brief Tests if this MoveIt version is Melodic or higher. */
-#define ROBOWFLEX_MOVEIT_ISOMETRY (ROBOWFLEX_MOVEIT_VERSION >= 10006u)
+#define ROBOWFLEX_MOVEIT_ISOMETRY (ROBOWFLEX_MOVEIT_VERSION >= ROBOWFLEX_MOVEIT_VERSION_COMPUTE(0, 10, 6))
 
 ///
 /// Compiler Warning Helpers


### PR DESCRIPTION
Well, instead of using macros to compute things, we are just going to directly suss it out from the type information itself.

This finds what `robowflex::RobotPose` should be by getting the return type to `moveit::core::Transforms::getTransform()`.