### PR TITLE
new scene functions and some new object constructors

### DIFF
--- a/robowflex_library/CMakeLists.txt
+++ b/robowflex_library/CMakeLists.txt
@@ -87,7 +87,7 @@ list(APPEND LIBRARIES
   yaml-cpp
   )
 
-include_directories(${INCLUDES})
+include_directories(SYSTEM ${INCLUDES})
 link_directories(${catkin_LIBRARY_DIRS})
 add_library(${LIBRARY_NAME} ${SOURCES})
 set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})

--- a/robowflex_library/include/robowflex_library/geometry.h
+++ b/robowflex_library/include/robowflex_library/geometry.h
@@ -103,6 +103,24 @@ namespace robowflex
          */
         Geometry(ShapeType::Type type, const Eigen::Vector3d &dimensions, const std::string &resource = "");
 
+        /** \brief Constructor.
+         *  Builds and loads the specified geometry from a MoveIt shape.
+         *  \param[in] shape Shape to construct geometry from.
+         */
+        Geometry(const shapes::Shape &shape);
+
+        /** \brief Constructor.
+         *  Builds and loads the specified geometry from a MoveIt shape message.
+         *  \param[in] msg Shape message to construct geometry from.
+         */
+        Geometry(const shape_msgs::SolidPrimitive &msg);
+
+        /** \brief Constructor.
+         *  Builds and loads the specified geometry from a MoveIt shape message.
+         *  \param[in] msg Shape message to construct mesh geometry from.
+         */
+        Geometry(const shape_msgs::Mesh &msg);
+
         // non-copyable
         Geometry(const Geometry &) = delete;
         Geometry &operator=(const Geometry &) = delete;
@@ -154,7 +172,6 @@ namespace robowflex
          */
         const std::string &getResource() const;
 
-
         /** \brief Gets the dimensions of the geometry.
          *  \return The dimensions of geometry.
          */
@@ -171,11 +188,11 @@ namespace robowflex
          */
         bodies::Body *loadBody() const;
 
-        ShapeType::Type type_{ShapeType::Type::BOX};                 ///< Geometry Type.
-        const Eigen::Vector3d dimensions_{Eigen::Vector3d::Ones()};  ///< Dimensions to scale geometry.
-        std::string resource_{""};                                   ///< Resource locator for MESH types.
-        const shapes::ShapePtr shape_{nullptr};                      ///< Loaded shape.
-        const bodies::BodyPtr body_{nullptr};                        ///< Body operation.
+        ShapeType::Type type_{ShapeType::Type::BOX};           ///< Geometry Type.
+        Eigen::Vector3d dimensions_{Eigen::Vector3d::Ones()};  ///< Dimensions to scale geometry.
+        std::string resource_{""};                             ///< Resource locator for MESH types.
+        shapes::ShapePtr shape_{nullptr};                      ///< Loaded shape.
+        bodies::BodyPtr body_{nullptr};                        ///< Body operation.
     };
 }  // namespace robowflex
 

--- a/robowflex_library/include/robowflex_library/scene.h
+++ b/robowflex_library/include/robowflex_library/scene.h
@@ -107,6 +107,18 @@ namespace robowflex
         void updateCollisionObject(const std::string &name, const GeometryConstPtr &geometry,
                                    const RobotPose &pose);
 
+        /** \brief Returns a list of all the names of collision objects in the scene.
+         *  \return A list of all the collision objects in the scene.
+         */
+        std::vector<std::string> getCollisionObjects() const;
+
+        /** \brief Returns a representation of a collision object in the scene as a Geometry.
+         *  If object has multiple geometries, returns the first.
+         *  \param[in] name Name of the object to extract.
+         *  \return A representation of the collision object as a Geometry.
+         */
+        GeometryPtr getObjectGeometry(const std::string &name) const;
+
         /** \brief Removes an object from the planning scene.
          *  \param[in] name Name of object to remove.
          */

--- a/robowflex_library/include/robowflex_library/scene.h
+++ b/robowflex_library/include/robowflex_library/scene.h
@@ -113,7 +113,7 @@ namespace robowflex
         std::vector<std::string> getCollisionObjects() const;
 
         /** \brief Returns a representation of a collision object in the scene as a Geometry.
-         *  If object has multiple geometries, returns the first.
+         *  If the object has multiple geometries, returns the first.
          *  \param[in] name Name of the object to extract.
          *  \return A representation of the collision object as a Geometry.
          */
@@ -125,6 +125,7 @@ namespace robowflex
         void removeCollisionObject(const std::string &name);
 
         /** \brief Get the current pose of a collision object.
+         *  If the object has multiple geometries, returns the pose of the first.
          *  \param[in] name Name of object to get pose for.
          *  \return Pose of the object.
          */

--- a/robowflex_library/src/geometry.cpp
+++ b/robowflex_library/src/geometry.cpp
@@ -97,6 +97,64 @@ Geometry::Geometry(ShapeType::Type type, const Eigen::Vector3d &dimensions, cons
 {
 }
 
+Geometry::Geometry(const shapes::Shape &shape)
+{
+    switch (shape.type)
+    {
+        case shapes::ShapeType::BOX:
+        {
+            type_ = ShapeType::BOX;
+            const auto &box = static_cast<const shapes::Box &>(shape);
+            dimensions_ = Eigen::Vector3d{box.size[0], box.size[1], box.size[2]};
+            shape_.reset(loadShape());
+            break;
+        }
+        case shapes::ShapeType::SPHERE:
+        {
+            type_ = ShapeType::SPHERE;
+            const auto &sphere = static_cast<const shapes::Sphere &>(shape);
+            dimensions_ = Eigen::Vector3d{sphere.radius, 0, 0};
+            shape_.reset(loadShape());
+            break;
+        }
+        case shapes::ShapeType::CYLINDER:
+        {
+            type_ = ShapeType::CYLINDER;
+            const auto &cylinder = static_cast<const shapes::Cylinder &>(shape);
+            dimensions_ = Eigen::Vector3d{cylinder.radius, cylinder.length, 0};
+            shape_.reset(loadShape());
+            break;
+        }
+        case shapes::ShapeType::CONE:
+        {
+            type_ = ShapeType::CONE;
+            const auto &cone = static_cast<const shapes::Cone &>(shape);
+            dimensions_ = Eigen::Vector3d{cone.radius, cone.length, 0};
+            shape_.reset(loadShape());
+            break;
+        }
+        case shapes::ShapeType::MESH:
+        {
+            type_ = ShapeType::MESH;
+            const auto &mesh = static_cast<const shapes::Mesh &>(shape);
+            shape_.reset(mesh.clone());
+            break;
+        }
+        default:
+            throw Exception(1, "Invalid type for geometry.");
+    }
+
+    body_.reset(loadBody());
+}
+
+Geometry::Geometry(const shape_msgs::SolidPrimitive &msg) : Geometry(*shapes::constructShapeFromMsg(msg))
+{
+}
+
+Geometry::Geometry(const shape_msgs::Mesh &msg) : Geometry(*shapes::constructShapeFromMsg(msg))
+{
+}
+
 shapes::Shape *Geometry::loadShape() const
 {
     switch (type_)

--- a/robowflex_library/src/scene.cpp
+++ b/robowflex_library/src/scene.cpp
@@ -149,6 +149,23 @@ void Scene::updateCollisionObject(const std::string &name, const GeometryConstPt
     world->addToObject(name, geometry->getShape(), pose);
 }
 
+std::vector<std::string> Scene::getCollisionObjects() const
+{
+    auto &world = scene_->getWorld();
+    return world->getObjectIds();
+}
+
+GeometryPtr Scene::getObjectGeometry(const std::string &name) const
+{
+    auto &world = scene_->getWorld();
+
+    const auto &obj = world->getObject(name);
+    if (obj)
+        return std::make_shared<Geometry>(*obj->shapes_[0]);
+
+    return nullptr;
+}
+
 void Scene::removeCollisionObject(const std::string &name)
 {
     scene_->getWorldNonConst()->removeObject(name);

--- a/robowflex_library/src/scene.cpp
+++ b/robowflex_library/src/scene.cpp
@@ -163,6 +163,7 @@ GeometryPtr Scene::getObjectGeometry(const std::string &name) const
     if (obj)
         return std::make_shared<Geometry>(*obj->shapes_[0]);
 
+    ROS_WARN("Object %1% does not exist in scene!", name.c_str());
     return nullptr;
 }
 

--- a/robowflex_movegroup/CMakeLists.txt
+++ b/robowflex_movegroup/CMakeLists.txt
@@ -30,7 +30,7 @@ catkin_package(
   INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/include
   )
 
-include_directories(${CMAKE_CURRENT_LIST_DIR}/include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} yaml-cpp)
+include_directories(SYSTEM ${CMAKE_CURRENT_LIST_DIR}/include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} yaml-cpp)
 link_directories(${catkin_LIBRARY_DIRS})
 
 add_library(${LIBRARY_NAME}

--- a/robowflex_ompl/CMakeLists.txt
+++ b/robowflex_ompl/CMakeLists.txt
@@ -28,7 +28,7 @@ catkin_package(
   )
 
 if (moveit_planners_ompl_DIR)
-  include_directories(${CMAKE_CURRENT_LIST_DIR}/include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+  include_directories(SYSTEM ${CMAKE_CURRENT_LIST_DIR}/include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
   link_directories(${catkin_LIBRARY_DIRS})
 
   add_library(${LIBRARY_NAME}

--- a/robowflex_tesseract/CMakeLists.txt
+++ b/robowflex_tesseract/CMakeLists.txt
@@ -43,7 +43,7 @@ catkin_package(
   )
 
 if (tesseract_planning_DIR)
-  include_directories(${CMAKE_CURRENT_LIST_DIR}/include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${OMPL_INCLUDE_DIRS})
+  include_directories(SYSTEM ${CMAKE_CURRENT_LIST_DIR}/include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${OMPL_INCLUDE_DIRS})
   link_directories(${catkin_LIBRARY_DIRS} ${OMPL_LIBS})
 
   add_library(${LIBRARY_NAME}

--- a/tmpack/CMakeLists.txt
+++ b/tmpack/CMakeLists.txt
@@ -60,7 +60,7 @@ if (GFLAGS_FOUND)
     gflags
     )
 
-  include_directories(${INCLUDES})
+  include_directories(SYSTEM ${INCLUDES})
   link_directories(${catkin_LIBRARY_DIRS})
   add_library(${LIBRARY_NAME} ${SOURCES})
   set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})


### PR DESCRIPTION
What it says on the tin. Added some new functions for getting object information from a planning scene as well as constructors to construct geometry from the representations that _MoveIt!_ uses.

Additionally, `SYSTEM` was added to the includes to prevent a bunch of spurious warnings from the included headers.