### PR TITLE
support for user-defined benchmark metrics

### DIFF
--- a/robowflex_library/include/robowflex_library/benchmarking.h
+++ b/robowflex_library/include/robowflex_library/benchmarking.h
@@ -136,6 +136,7 @@ namespace robowflex
 
                 std::map<std::string, MetricValue> metrics;  ///< Map of metric name to value.
             };
+
             /** \brief Type for callback function to add additional metrics
              */
             using ComputeMetricCallbackFn =
@@ -207,7 +208,7 @@ namespace robowflex
             std::function<Results::ComputeMetricCallbackFn(const BenchmarkRequest &)>;
 
         /** \brief Set the function that returns a callback function for computing user-defined metrics.
-         *  \param[in] metricCBAlloc
+         *  \param[in] metric_alloc The allocator function.
          */
         void setMetricCallbackFnAllocator(MetricCallbackFnAllocator metric_alloc);
 
@@ -217,9 +218,8 @@ namespace robowflex
         void captureProgress(const std::map<std::string, Planner::ProgressProperty> &properties,
                              std::vector<std::map<std::string, std::string>> &progress, double rate);
 
-        std::map<std::string, BenchmarkRequest> requests_;     ///< Requests to benchmark.
-        MetricCallbackFnAllocator metric_callback_allocator_;  ///< Allocation function that returns function
-                                                               ///< for user callbacks.
+        std::map<std::string, BenchmarkRequest> requests_;         ///< Requests to benchmark.
+        MetricCallbackFnAllocator metric_callback_allocator_;      ///< User metric callback allocator.
 
         std::mutex solved_mutex_;  ///< Lock used for progress property computation.
         bool solved_;              ///< Has the current benchmarking run been solved?

--- a/robowflex_library/src/benchmarking.cpp
+++ b/robowflex_library/src/benchmarking.cpp
@@ -178,6 +178,7 @@ void Benchmarker::benchmark(const std::vector<BenchmarkOutputterPtr> &outputs, c
 
             // Capture planner progress.
             const auto &pp = planner->getProgressProperties(scene, msg);
+
             std::vector<std::map<std::string, std::string>> progress;
             if (not pp.empty())
             {

--- a/robowflex_ompl/include/robowflex_ompl/ompl_interface.h
+++ b/robowflex_ompl/include/robowflex_ompl/ompl_interface.h
@@ -66,18 +66,21 @@ namespace robowflex
             ompl_interface::ModelBasedPlanningContextPtr getPlanningContext(
                 const SceneConstPtr &scene, const planning_interface::MotionPlanRequest &request) const;
 
+            /** \brief Get the last OMPL simple setup used in planning.
+             *  \return The last OMPL simple setup used.
+             */
+            ompl::geometric::SimpleSetupPtr getLastSimpleSetup() const;
+
             std::map<std::string, Planner::ProgressProperty>
             getProgressProperties(const SceneConstPtr &scene,
                                   const planning_interface::MotionPlanRequest &request) const override;
 
             std::vector<std::string> getPlannerConfigs() const override;
 
-            ompl::geometric::SimpleSetupPtr getLastSS() const;
-
         private:
             std::unique_ptr<ompl_interface::OMPLInterface> interface_{nullptr};  ///< Planning interface.
             std::vector<std::string> configs_;                                   ///< Planning configurations.
-            ompl::geometric::SimpleSetupPtr ss_;  ///< Last ompl simple setup used.
+            ompl::geometric::SimpleSetupPtr ss_;  ///< Last OMPL simple setup used for planning.
         };
     }  // namespace OMPL
 }  // namespace robowflex

--- a/robowflex_ompl/scripts/fetch_ompl_benchmark.cpp
+++ b/robowflex_ompl/scripts/fetch_ompl_benchmark.cpp
@@ -43,8 +43,29 @@ int main(int argc, char **argv)
     Benchmarker benchmark;
     benchmark.addBenchmarkingRequest("joint", scene, planner, request);
 
+    // Install a custom metric computation function.
+    benchmark.setMetricCallbackFnAllocator([&](const Benchmarker::BenchmarkRequest &request) {
+        return [&](planning_interface::MotionPlanResponse &run, Benchmarker::Results::Run &metrics) {
+            const auto &planner =
+                std::dynamic_pointer_cast<const OMPL::OMPLInterfacePlanner>(std::get<1>(request));
+
+            if (not planner)
+                ROS_FATAL("Unexpected planner!");
+
+            const auto &ss = planner->getLastSimpleSetup();
+
+            ompl::base::PlannerData pd(ss->getSpaceInformation());
+            ss->getPlannerData(pd);
+
+            metrics.metrics["goal_distance"] = ss->getProblemDefinition()->getSolutionDifference();
+            metrics.metrics["num_vertices"] = (int)pd.numVertices();
+        };
+    });
+
     Benchmarker::Options options;
-    options.runs = 3;
+    options.runs = 5;
+    options.options =
+        Benchmarker::WAYPOINTS | Benchmarker::CORRECT | Benchmarker::LENGTH | Benchmarker::SMOOTHNESS;
 
     // Output results to an OMPL benchmarking file.
     benchmark.benchmark({std::make_shared<OMPLBenchmarkOutputter>("robowflex_fetch_test/")}, options);

--- a/robowflex_ompl/src/ompl_interface.cpp
+++ b/robowflex_ompl/src/ompl_interface.cpp
@@ -57,8 +57,10 @@ planning_interface::MotionPlanResponse OMPL::OMPLInterfacePlanner::plan(
         ROS_ERROR("Context was not set!");
         return response;
     }
+
     ss_ = context->getOMPLSimpleSetup();
     context->solve(response);
+
     return response;
 }
 
@@ -72,7 +74,7 @@ std::map<std::string, Planner::ProgressProperty> OMPL::OMPLInterfacePlanner::get
     return planner->getPlannerProgressProperties();
 }
 
-ompl::geometric::SimpleSetupPtr OMPL::OMPLInterfacePlanner::getLastSS() const
+ompl::geometric::SimpleSetupPtr OMPL::OMPLInterfacePlanner::getLastSimpleSetup() const
 {
     return ss_;
 }


### PR DESCRIPTION
Note that this PR is against the progress-properties branch. I can rebase against master if needed.

It still doesn't work in the way I want to. I use this new functionality in my own code like so:
```cpp
struct GoalDistanceFunctor
{
    const Benchmarker::BenchmarkRequest &request;

    void operator()(planning_interface::MotionPlanResponse &run, Benchmarker::Results::Run &metrics)
    {
        auto planner = std::dynamic_pointer_cast<const OMPL::OMPLInterfacePlanner>(std::get<1>(request));
        if (planner == nullptr)
            ROS_FATAL("Unexpected planner!");
        auto context = planner->getPlanningContext(std::get<0>(request),
                                                                std::get<2>(request)->getRequestConst());
        metrics.metrics["goal_distance"] =
            context->getOMPLSimpleSetup()->getProblemDefinition()->getSolutionDifference();
        
        auto ss = context->getOMPLSimpleSetup();
        ROS_ERROR_STREAM("cb: " << ss->haveSolutionPath() << " " << ss->haveExactSolutionPath() << " " << ss->getProblemDefinition()->getSolutionCount());
    }
};

Benchmarker::Results::ComputeMetricCallbackFn callbackFnAllocator(const Benchmarker::BenchmarkRequest &request)
{
    return GoalDistanceFunctor{request};
}

...

        Benchmarker benchmark;
        benchmark.setMetricCallbackFnAllocator(callbackFnAllocator);
        benchmark.addBenchmarkingRequest(scene_file_name, scene, planner, request);
```
The goal_distance is always -1, which corresponds to no path being found. The debug print statement confirms that there is no solution. However, the rest of the metric indicate a solution *was* found. So somehow things get cleared. Any ideas on how I can avoid this?