### PR TITLE
DART: Fix std::bad_function_call when there is an interactive marker + reparent

### DIFF
--- a/robowflex_dart/src/gui.cpp
+++ b/robowflex_dart/src/gui.cpp
@@ -100,7 +100,12 @@ Window::InteractiveReturn Window::createInteractiveMarker(const InteractiveOptio
 
     auto callback = options.callback;
     r.signal = r.target->onTransformUpdated.connect([callback](const dart::dynamics::Entity *entity) {
-        callback(dynamic_cast<const dart::gui::osg::InteractiveFrame *>(entity));
+        if (entity)
+        {
+            auto cast = dynamic_cast<const dart::gui::osg::InteractiveFrame *>(entity);
+            if (cast and callback)
+                callback(cast);
+        }
     });
 
     return r;


### PR DESCRIPTION
Closes an issue that Thomas reported.