### PR TITLE
Always load the parent group in loadKinematics()

### DIFF
--- a/robowflex_library/include/robowflex_library/robot.h
+++ b/robowflex_library/include/robowflex_library/robot.h
@@ -193,12 +193,13 @@ namespace robowflex
          */
         void setSRDFPostProcessAddFloatingJoint(const std::string &name);
 
-        /** \brief Loads the kinematics plugin for a joint group or its subgroups. No kinematics are loaded by
-         * default.
+        /** \brief Loads the kinematics plugin for a joint group and its subgroups. No kinematics are loaded
+         * by default.
          *  \param[in] group Joint group name to load.
+         *  \param[in] load_subgroups Load kinematic solvers for subgroups of the requested group.
          *  \return True on success, false on failure.
          */
-        bool loadKinematics(const std::string &group);
+        bool loadKinematics(const std::string &group, bool load_subgroups = true);
 
         /** \} */
 

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -361,6 +361,9 @@ void Robot::loadRobotModel(const std::string &description)
 
 bool Robot::loadKinematics(const std::string &group_name, bool load_subgroups)
 {
+    // Needs to be called first to read the groups defined in the SRDF from the ROS params.
+    robot_model::SolverAllocatorFn allocator = kinematics_->getLoaderFunction(loader_->getSRDF());
+
     const auto &groups = kinematics_->getKnownGroups();
     if (groups.empty())
     {
@@ -387,7 +390,6 @@ bool Robot::loadKinematics(const std::string &group_name, bool load_subgroups)
     if (std::find(groups.begin(), groups.end(), group_name) != groups.end())
         load_names.emplace_back(group_name);
 
-    robot_model::SolverAllocatorFn allocator = kinematics_->getLoaderFunction(loader_->getSRDF());
     auto timeout = kinematics_->getIKTimeout();
 
     for (const auto &name : load_names)

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -369,28 +369,28 @@ bool Robot::loadKinematics(const std::string &group_name)
     const auto &groups = kinematics_->getKnownGroups();
     if (groups.empty())
     {
-        RBX_WARN("No kinematics plugins defined. Fill and load kinematics.yaml!");
+        RBX_ERROR("No kinematics plugins defined. Fill and load kinematics.yaml!");
         return false;
     }
 
     if (!model_->hasJointModelGroup(group_name))
     {
-        RBX_WARN("No JMG defined for `%s`!", group_name);
+        RBX_ERROR("No JMG defined for `%s`!", group_name);
         return false;
     }
 
     const auto &subgroups = model_->getJointModelGroup(group_name)->getSubgroupNames();
-    // if no subgroups exist use the given group name.
-    auto group_names = subgroups.empty() ? std::vector<std::string>{group_name} : subgroups;
+    std::vector<std::string> load_names(subgroups);
+    load_names.push_back(group_name);
     auto timeout = kinematics_->getIKTimeout();
 
-    for (const auto &name : group_names)
+    for (const auto &name : load_names)
     {
         if (!model_->hasJointModelGroup(name) ||
             std::find(groups.begin(), groups.end(), name) == groups.end())
         {
             RBX_WARN("No JMG or Kinematics defined for `%s`!", name);
-            return false;
+            continue;
         }
 
         robot_model::JointModelGroup *jmg = model_->getJointModelGroup(name);

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -380,7 +380,7 @@ bool Robot::loadKinematics(const std::string &group_name, bool load_subgroups)
     if (load_subgroups)
     {
         const auto &subgroups = model_->getJointModelGroup(group_name)->getSubgroupNames();
-        load_names.insert(subgroups.begin(), subgroups.end());
+        load_names.insert(load_names.end(), subgroups.begin(), subgroups.end());
     }
 
     // Check if this group also has an associated kinematics solver to load.
@@ -388,7 +388,7 @@ bool Robot::loadKinematics(const std::string &group_name, bool load_subgroups)
         load_names.emplace_back(group_name);
 
     robot_model::SolverAllocatorFn allocator = kinematics_->getLoaderFunction(loader_->getSRDF());
-    const auto &timeout = kinematics_->getIKTimeout();
+    auto timeout = kinematics_->getIKTimeout();
 
     for (const auto &name : load_names)
     {

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -381,7 +381,10 @@ bool Robot::loadKinematics(const std::string &group_name)
 
     const auto &subgroups = model_->getJointModelGroup(group_name)->getSubgroupNames();
     std::vector<std::string> load_names(subgroups);
-    load_names.push_back(group_name);
+
+    if (std::find(groups.begin(), groups.end(), group_name) != groups.end())
+        load_names.push_back(group_name);
+
     auto timeout = kinematics_->getIKTimeout();
 
     for (const auto &name : load_names)
@@ -389,8 +392,8 @@ bool Robot::loadKinematics(const std::string &group_name)
         if (!model_->hasJointModelGroup(name) ||
             std::find(groups.begin(), groups.end(), name) == groups.end())
         {
-            RBX_WARN("No JMG or Kinematics defined for `%s`!", name);
-            continue;
+            RBX_ERROR("No JMG or Kinematics defined for `%s`!", name);
+            return false;
         }
 
         robot_model::JointModelGroup *jmg = model_->getJointModelGroup(name);


### PR DESCRIPTION
Fixes the issue with PR #203 where a parent group containing subgroups is not itself loaded (e.g. the Fetch arm_with_torso).