### PR TITLE
Symlink resolution fix

### DIFF
--- a/robowflex_dart/CMakeLists.txt
+++ b/robowflex_dart/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_MODULE_PATH
 include(CompileOptions)
 include(HelperFunctions)
 
-find_package(DART #REQUIRED
+find_package(DART 6 REQUIRED
   COMPONENTS utils utils-urdf gui-osg
   OPTIONAL_COMPONENTS
   CONFIG

--- a/robowflex_library/src/io.cpp
+++ b/robowflex_library/src/io.cpp
@@ -46,17 +46,16 @@ namespace
 
     boost::filesystem::path expandSymlinks(const boost::filesystem::path &in)
     {
+        // Check if the path has a symlink before expansion to avoid error.
         boost::filesystem::path out;
         for (const auto &p : in)
         {
             auto tmp = out / p;
             if (boost::filesystem::is_symlink(tmp))
-                out = boost::filesystem::read_symlink(tmp);
-            else
-                out /= p;
+                return boost::filesystem::canonical(in);
         }
 
-        return out;
+        return in;
     }
 
     boost::filesystem::path expandPath(const boost::filesystem::path &in)


### PR DESCRIPTION
There was a small error in how symlinks were resolved, which caused breaking in package URI lookups.