### PR TITLE
update readme for installing DART 6

### DIFF
--- a/robowflex_dart/README.md
+++ b/robowflex_dart/README.md
@@ -59,7 +59,7 @@ sudo apt-get install \
 
 Then, add DART to your local catkin workspace:
 ```sh
-git clone git://github.com/dartsim/dart.git
+git clone -b v6.10.0 git://github.com/dartsim/dart.git
 ```
 
 ## OMPL Installation


### PR DESCRIPTION
The robowflex_dart requires DART version 6 to be installed. Updating README to reflect that.