### PR TITLE
Moved DART find packages into if block to avoid compilation failure.

### DIFF
--- a/robowflex_dart/CMakeLists.txt
+++ b/robowflex_dart/CMakeLists.txt
@@ -11,13 +11,13 @@ set(CMAKE_MODULE_PATH
 include(CompileOptions)
 include(HelperFunctions)
 
+find_package(DART 6 QUIET
+  COMPONENTS utils utils-urdf gui-osg
+  OPTIONAL_COMPONENTS
+  CONFIG)
+
 
 if (DART_LIBRARIES)
-
-  find_package(DART 6 REQUIRED
-    COMPONENTS utils utils-urdf gui-osg
-    OPTIONAL_COMPONENTS
-    CONFIG)
 
   find_package(Boost REQUIRED COMPONENTS filesystem system program_options)
   include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/robowflex_dart/CMakeLists.txt
+++ b/robowflex_dart/CMakeLists.txt
@@ -11,13 +11,14 @@ set(CMAKE_MODULE_PATH
 include(CompileOptions)
 include(HelperFunctions)
 
-find_package(DART 6 REQUIRED
-  COMPONENTS utils utils-urdf gui-osg
-  OPTIONAL_COMPONENTS
-  CONFIG
-  )
 
 if (DART_LIBRARIES)
+
+  find_package(DART 6 REQUIRED
+    COMPONENTS utils utils-urdf gui-osg
+    OPTIONAL_COMPONENTS
+    CONFIG)
+
   find_package(Boost REQUIRED COMPONENTS filesystem system program_options)
   include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
   list(APPEND LIBRARIES ${Boost_LIBRARIES})


### PR DESCRIPTION
Just moved the find_package call in the CMake file for robowflex_dart to below the if statement that checks for the DART library. Without doing this, the package fails compilation on machines without DART installed.