### PR TITLE
update a note about ACO

### DIFF
--- a/robowflex_library/include/robowflex_library/scene.h
+++ b/robowflex_library/include/robowflex_library/scene.h
@@ -39,7 +39,9 @@ namespace robowflex
      *
      *  The Scene class is a wrapper around _MoveIt!_'s planning_scene::PlanningScene, providing access to set
      * and manipulate collision objects, attach and detach objects to the robot, and so on. There are also
-     * utilities to load and save planning scenes from YAML files (toYAMLFile() and fromYAMLFile()).
+     * utilities to load and save planning scenes from YAML files (toYAMLFile() and fromYAMLFile()). Note this
+     * class creates a copy of Robot, so the attached collision objects information are not synchronized to
+     * the original Robot instance.
      */
     class Scene : public ID
     {

--- a/robowflex_library/include/robowflex_library/scene.h
+++ b/robowflex_library/include/robowflex_library/scene.h
@@ -39,9 +39,11 @@ namespace robowflex
      *
      *  The Scene class is a wrapper around _MoveIt!_'s planning_scene::PlanningScene, providing access to set
      * and manipulate collision objects, attach and detach objects to the robot, and so on. There are also
-     * utilities to load and save planning scenes from YAML files (toYAMLFile() and fromYAMLFile()). Note this
-     * class creates a copy of Robot, so the attached collision objects information are not synchronized to
-     * the original Robot instance.
+     * utilities to load and save planning scenes from YAML files (toYAMLFile() and fromYAMLFile()).
+     *  Note that this class has *its own* robot state, separate from the one in the provided Robot. For
+     * example, using attachObject() without providing your own state will attach the object to this internal
+     * state. Information between this state and the Robot's scratch state are not synchronized, you must do
+     * this manually.
      */
     class Scene : public ID
     {
@@ -214,7 +216,7 @@ namespace robowflex
         bool attachObject(const std::string &name);
 
         /** \brief Attach the named collision object \a name to the default end-effector of the given robot \a
-         * state Only works if there is one end-effector in the system. Uses all end-effector links as allowed
+         *  state. Only works if there is one end-effector in the system. Uses all end-effector links as allowed
          *  touch links.
          *  \param[in] name Name of collision to attach.
          *  \param[in] state State of robot the object will be attached to
@@ -232,7 +234,7 @@ namespace robowflex
                           const std::vector<std::string> &touch_links);
 
         /** \brief Attach the named collision object \a name to the link \a ee_link of the given robot \a
-         * state
+         *  state
          *  \param[in] state State of the robot to attach.
          *  \param[in] name Name of object to attach.
          *  \param[in] ee_link Link to attach object to.

--- a/robowflex_library/include/robowflex_library/scene.h
+++ b/robowflex_library/include/robowflex_library/scene.h
@@ -216,8 +216,8 @@ namespace robowflex
         bool attachObject(const std::string &name);
 
         /** \brief Attach the named collision object \a name to the default end-effector of the given robot \a
-         *  state. Only works if there is one end-effector in the system. Uses all end-effector links as allowed
-         *  touch links.
+         *  state. Only works if there is one end-effector in the system. Uses all end-effector links as
+         *  allowed touch links.
          *  \param[in] name Name of collision to attach.
          *  \param[in] state State of robot the object will be attached to
          *  \return True on success, false on failure.


### PR DESCRIPTION
The attachObject APIs only attach the object to the private copy of the robot. If anyone use their original robot instance to set initial state for motion planning, that state would not have the object attached. Documentation updated to include a note on this issue,