### PR TITLE
Modify TrajOptPlanner to allow a user to add custom terms to the trajectory optimization

### DIFF
--- a/robowflex_tesseract/CMakeLists.txt
+++ b/robowflex_tesseract/CMakeLists.txt
@@ -45,6 +45,7 @@ if (tesseract_planning_DIR)
   add_script(fetch_tabletop_inits)
   add_script(fetch_tabletop_planning_time)
   add_script(fetch_trajopt)
+  add_script(ur5_custom_planning)
 
   install_scripts()
   install_tests()

--- a/robowflex_tesseract/README.md
+++ b/robowflex_tesseract/README.md
@@ -20,18 +20,22 @@ If the user can not or do not want to modify the robot's srdf, an overloaded ver
 - **Plan**: In addition to the standard plan() method from robowflex::Planner, TrajOptPlanner offers additional planning interfaces. One that stands out receives the scene, the start state and a goal pose for a given link. This interface allows the user to perform planning without a full goal state specification (i.e., no need to perform IK queries). Instead, it creates cartesian pose constraints on the last waypoint of the trajectory for the given link (e.g., the end effector). 
 All the additional versions of the plan() method return a PlannerResult structure with information about the planner convergence status. In particular, PlannerResult is a pair of booleans. The first field specifies whether the optimization algorithm converged or not. The second field specifies whether the resulting trajectory is collision-free or not. Note that it is possible that the optimization converges to a trajectory that is in collision (i.e., PlannerResult->first = true, PlannerResult->second = false) because the collision avoidance terms can be defined as costs instead of constraints.
 
-# Scripts
+### Custom terms in TrajOpt
+The original implementation of [trajopt_ros](https://github.com/ros-industrial-consortium/trajopt_ros/tree/kinetic-devel) allows the user to incorporate custom terms to the trajectory optimization formulation. These custom terms are usually out of the scope of the standard motion planning problem but they might come handy for specific robotic tasks. The standard supported terms are usually joint/cartesian cost/constraints for positions, velocities and accelerations.
 
-5 different scripts (`scripts` directory) show how the planner can be used in different ways. Some of the scripts load the planning request and scene from yaml files (`scenes` folder) and require to run RVIZ to visualize the scene, states and output trajectory:
+`robowflex::TrajOptPlanner` exposes this feature by letting the user inherit from the planner class and implement their own `robowflex::TrajOptPlanner::plan()` method. Here, the user is responsible for adding all the required terms to construct the trajectory optimization problem. The method expects as arguments a `robowflex::Scene` and a `robot_state:RobotState` start state, as this is the minimum information required to create a trajectory optimization problem. Notice that a goal state can be defined using custom terms (e.g., position cartesian terms for the robot's end-effector). 
+
+## Scripts
+6 different scripts (`scripts` directory) show how the planner can be used in different ways. Some of the scripts load the planning request and scene from yaml files (`scenes` folder) and require to run RVIZ to visualize the scene, states and output trajectory:
 
 - fetch_trajopt.cpp: Shows the simplest setup for planning using an empty scene and given start and goal states.
-- fetch_tabletop_goalstate: Shows how to plan for a given scene, start and goal state.
+- fetch_tabletop_goalstate.cpp: Shows how to plan for a given scene, start and goal state.
 - fetch_tabletop_goalpose.cpp: Shows how to plan for a given scene, start state and goal pose for the end effector.
 - fetch_tabletop_inits.cpp: Shows how to plan for a given scene, start and goal state using different initial trajectories, namely stationary and joint_interpolated (straight-line).
-- fetch_tabletop_planning_time: Shows how to plan for a given scene, start and goal with different behaviors for the planner. The first behavior runs the planner just once and returns  right away. The second behavior allows the planner to run more than once and runs until a feasible solution (collision-free) is found or the time limit is reached. The final behavior forces the planner to take all the available time and returns the best found solution at the end. In the two latter cases, the planner is initialized with a perturbed version of the given initial trajectory every time is run.
+- fetch_tabletop_planning_time.cpp: Shows how to plan for a given scene, start and goal with different behaviors for the planner. The first behavior runs the planner just once and returns right away. The second behavior allows the planner to run more than once and runs until a feasible solution (collision-free) is found or the time limit is reached. The final behavior forces the planner to take all the available time and returns the best found solution at the end. In the two latter cases, the planner is initialized with a perturbed version of the given initial trajectory every time is run.
+- ur5_custom_planning.cpp: Shows how to build a custom planner by defining cartesian constraints for the robot's end-effector at multiple timesteps in the trajectory.
 
-# Installation Instructions
-
+## Installation Instructions
 Both Tesseract and TrajOpt can be added as catkin packages in your workspace. 
 Currently, Robowflex Tesseract uses the `kinetic-devel` branch of both [tesseract](https://github.com/ros-industrial-consortium/tesseract/tree/kinetic-devel) and [trajopt](https://github.com/ros-industrial-consortium/trajopt_ros/tree/kinetic-devel).
 The Tesseract module can be difficult to compile and integrate in a complex ROS workspace.

--- a/robowflex_tesseract/include/robowflex_tesseract/trajopt_planner.h
+++ b/robowflex_tesseract/include/robowflex_tesseract/trajopt_planner.h
@@ -235,6 +235,13 @@ namespace robowflex
                            const std::string &start_link, const RobotPose &goal_pose,
                            const std::string &goal_link);
 
+        /** \brief Plan a motion using custom terms specified by the user.
+         *  \param[in] scene A planning scene to compute the plan in.
+         *  \param[in] start_state Start state for the robot.
+         *  \return Planner result with convergence and collision status.
+         */
+        virtual PlannerResult plan(const SceneConstPtr &scene, const robot_state::RobotStatePtr &start_state);
+
         /** \brief Get planner configurations offered by this planner.
          *  Any of the configurations returned can be set as the planner for a motion planning
          *  query sent to plan().
@@ -254,11 +261,16 @@ namespace robowflex
 
         /** \} */
 
-    private:
+    protected:
         /** \brief Create a TrajOpt problem construction info object with default values.
          *  \param[out] pci Pointer to problem construction info initialized.
          */
         void problemConstructionInfo(std::shared_ptr<trajopt::ProblemConstructionInfo> pci) const;
+
+        /** \brief Add velocity cost to the trajectory optimization.
+         *  \param[out] pci Pointer to problem construction info with velocity cost added.
+         */
+        void addVelocityCost(std::shared_ptr<trajopt::ProblemConstructionInfo> pci) const;
 
         /** \brief Add collision avoidance cost to the trajectory optimization for all waypoints.
          *  \param[out] pci Pointer to problem construction info with collision avoidance added.

--- a/robowflex_tesseract/scripts/ur5_custom_planning.cpp
+++ b/robowflex_tesseract/scripts/ur5_custom_planning.cpp
@@ -32,7 +32,7 @@ public:
     };
 
     CustomTrajOptPlanner(const RobotPtr &robot, const std::string &group_name)
-        : TrajOptPlanner(robot, group_name, "custom_trajopt")
+      : TrajOptPlanner(robot, group_name, "custom_trajopt")
     {
     }
 
@@ -73,8 +73,7 @@ private:
             pose_constraint->link = term.link;
             pose_constraint->timestep = term.timestep;
             pose_constraint->xyz = term.pose.translation();
-            pose_constraint->wxyz =
-                Eigen::Vector4d(rotation.w(), rotation.x(), rotation.y(), rotation.z());
+            pose_constraint->wxyz = Eigen::Vector4d(rotation.w(), rotation.x(), rotation.y(), rotation.z());
             pose_constraint->pos_coeffs = Eigen::Vector3d::Constant(term.pos_coeffs);
             pose_constraint->rot_coeffs = Eigen::Vector3d::Constant(term.rot_coeffs);
             pose_constraint->name = "pose_cnt_link_" + term.link + std::to_string(term.timestep);
@@ -127,7 +126,7 @@ int main(int argc, char **argv)
         term.link = ee;
         term.pos_coeffs = 1.0;
         term.rot_coeffs = 1.0;
-        
+
         planner->constraints_.push_back(term);
     }
 

--- a/robowflex_tesseract/scripts/ur5_custom_planning.cpp
+++ b/robowflex_tesseract/scripts/ur5_custom_planning.cpp
@@ -1,0 +1,156 @@
+/* Author: Carlos Quintero Pena */
+
+#include <robowflex_library/detail/ur5.h>
+#include <robowflex_library/io/visualization.h>
+#include <robowflex_library/log.h>
+#include <robowflex_library/planning.h>
+#include <robowflex_library/robot.h>
+#include <robowflex_library/scene.h>
+#include <robowflex_library/trajectory.h>
+#include <robowflex_library/util.h>
+#include <robowflex_tesseract/conversions.h>
+#include <robowflex_tesseract/trajopt_planner.h>
+
+/* \file ur5_custom_planning.cpp
+ * Simple demonstration of how to use the TrajOptPlanner with the UR5 with custom terms in the optimization.
+ * This customized trajopt planner has end-effector pose constraints at specific timesteps of the trajectory.
+ */
+
+namespace robowflex
+{
+    class CustomTrajOptPlanner : public TrajOptPlanner
+    {
+    public:
+        struct CartCnt
+        {
+            RobotPose pose;
+            int timestep;
+            std::string link;
+            double pos_coeffs;
+            double rot_coeffs;
+        };
+
+        CustomTrajOptPlanner(const RobotPtr &robot, const std::string &group_name)
+          : TrajOptPlanner(robot, group_name, "custom_trajopt")
+        {
+        }
+
+        PlannerResult plan(const SceneConstPtr &scene, const robot_state::RobotStatePtr &start_state)
+        {
+            // This is required by any TrajOptPlanner::plan() method.
+            ref_state_ = std::make_shared<robot_state::RobotState>(*start_state);
+
+            // Transform robowflex scene to tesseract environment.
+            hypercube::sceneToTesseractEnv(scene, env_);
+
+            // Fill in the problem construction info and initialization.
+            auto pci = std::make_shared<trajopt::ProblemConstructionInfo>(env_);
+            problemConstructionInfo(pci);
+
+            // Add velocity cost.
+            addVelocityCost(pci);
+
+            // Add start state.
+            addStartState(start_state, pci);
+
+            // Add cartesian terms in constraints_.
+            addCartTerms(pci);
+
+            return solve(scene, pci);
+        }
+
+        std::vector<CartCnt> constraints_{};
+
+    private:
+        void addCartTerms(std::shared_ptr<trajopt::ProblemConstructionInfo> pci) const
+        {
+            for (const auto &term : constraints_)
+            {
+                Eigen::Quaterniond rotation(term.pose.linear());
+                auto pose_constraint = std::make_shared<trajopt::CartPoseTermInfo>();
+                pose_constraint->term_type = trajopt::TT_CNT;
+                pose_constraint->link = term.link;
+                pose_constraint->timestep = term.timestep;
+                pose_constraint->xyz = term.pose.translation();
+                pose_constraint->wxyz =
+                    Eigen::Vector4d(rotation.w(), rotation.x(), rotation.y(), rotation.z());
+                pose_constraint->pos_coeffs = Eigen::Vector3d::Constant(term.pos_coeffs);
+                pose_constraint->rot_coeffs = Eigen::Vector3d::Constant(term.rot_coeffs);
+                pose_constraint->name = "pose_cnt_link_" + term.link + std::to_string(term.timestep);
+
+                pci->cnt_infos.push_back(pose_constraint);
+            }
+        }
+    };
+}  // namespace robowflex
+
+using namespace robowflex;
+
+static const std::string GROUP = "manipulator";
+
+int main(int argc, char **argv)
+{
+    // Startup ROS
+    ROS ros(argc, argv);
+
+    // Create the default UR5 robot.
+    auto ur5 = std::make_shared<UR5Robot>();
+    ur5->initialize();
+
+    // Set start state and get the ee pose.
+    ur5->setGroupState(GROUP, {0.0677, -0.8235, 0.9860, -0.1624, 0.0678, 0.0});
+    const auto &ee = ur5->getModel()->getEndEffectors()[0]->getLinkModelNames()[0];
+    RobotPose pose = ur5->getLinkTF(ee);
+
+    // Create an RViz visualization helper.
+    IO::RVIZHelper rviz(ur5);
+    RBX_INFO("RViz Initialized! Press enter to continue (after your RViz is setup)...");
+    std::cin.get();
+
+    // Create and visualize scene.
+    auto scene = std::make_shared<Scene>(ur5);
+    scene->getCurrentState() = *ur5->getScratchState();
+    rviz.updateScene(scene);
+
+    // Create a custom TrajOpt planner
+    auto planner = std::make_shared<CustomTrajOptPlanner>(ur5, GROUP);
+    planner->initialize(GROUP);
+    planner->options.num_waypoints = 17;  // Set number of waypoints in trajectory.
+
+    // Define desired motion of the end-effector.
+    EigenSTL::vector_Vector3d directions = {
+        {0.0, -0.3, 0.0}, {0.0, 0.0, -0.2}, {0.0, 0.3, 0.0}, {0.0, 0.0, 0.2}};
+
+    for (size_t i = 0; i < directions.size(); ++i)
+    {
+        CustomTrajOptPlanner::CartCnt term;
+        pose.translate(directions[i]);
+        term.pose = pose;
+        term.timestep = (i + 1) * 4;
+        term.link = ee;
+        term.pos_coeffs = 1.0;
+        term.rot_coeffs = 1.0;
+        planner->constraints_.push_back(term);
+    }
+
+    // Do planning with cartesian constraints.
+    auto response = planner->plan(scene, ur5->getScratchState());
+    if (!response.first)
+    {
+        RBX_INFO("Optimization did not converge");
+        return 0;
+    }
+
+    // Publish the trajectory to a topic to display in RViz
+    Trajectory trajectory(planner->getTrajectory());
+    rviz.updateTrajectory(trajectory);
+
+    // Visualize the final pose.
+    scene->getCurrentState() = *ur5->getScratchState();
+    rviz.updateScene(scene);
+
+    RBX_INFO("Press enter to exit.");
+    std::cin.get();
+
+    return 0;
+}

--- a/robowflex_tesseract/src/trajopt_planner.cpp
+++ b/robowflex_tesseract/src/trajopt_planner.cpp
@@ -260,6 +260,9 @@ TrajOptPlanner::PlannerResult TrajOptPlanner::plan(const SceneConstPtr &scene,
         auto pci = std::make_shared<ProblemConstructionInfo>(env_);
         problemConstructionInfo(pci);
 
+        // Add velocity cost.
+        addVelocityCost(pci);
+
         // Add start state.
         addStartState(start_state, pci);
 
@@ -308,6 +311,9 @@ TrajOptPlanner::PlannerResult TrajOptPlanner::plan(const SceneConstPtr &scene,
         auto pci = std::make_shared<ProblemConstructionInfo>(env_);
         problemConstructionInfo(pci);
 
+        // Add velocity cost.
+        addVelocityCost(pci);
+
         // Add start state
         addStartState(start_state, pci);
 
@@ -348,6 +354,9 @@ TrajOptPlanner::PlannerResult TrajOptPlanner::plan(const SceneConstPtr &scene,
         // Fill in the problem construction info and initialization.
         auto pci = std::make_shared<ProblemConstructionInfo>(env_);
         problemConstructionInfo(pci);
+
+        // Add velocity cost.
+        addVelocityCost(pci);
 
         // Add start state
         addStartState(start_state, pci);
@@ -391,6 +400,9 @@ TrajOptPlanner::PlannerResult TrajOptPlanner::plan(const SceneConstPtr &scene, c
         auto pci = std::make_shared<ProblemConstructionInfo>(env_);
         problemConstructionInfo(pci);
 
+        // Add velocity cost.
+        addVelocityCost(pci);
+
         // Add start_pose for start_link.
         addStartPose(start_pose, start_link, pci);
 
@@ -402,6 +414,14 @@ TrajOptPlanner::PlannerResult TrajOptPlanner::plan(const SceneConstPtr &scene, c
 
         return solve(scene, pci);
     }
+
+    return PlannerResult(false, false);
+}
+
+TrajOptPlanner::PlannerResult TrajOptPlanner::plan(const SceneConstPtr &scene,
+                                                   const robot_state::RobotStatePtr &start_state)
+{
+    RBX_ERROR("You need to implement virtual method TrajOptPlanner::plan() in your derived class");
 
     return PlannerResult(false, false);
 }
@@ -442,7 +462,10 @@ void TrajOptPlanner::problemConstructionInfo(std::shared_ptr<ProblemConstruction
 
     if (options.verbose)
         RBX_INFO("TrajOpt initialization: %d", init_type_);
+}
 
+void TrajOptPlanner::addVelocityCost(std::shared_ptr<trajopt::ProblemConstructionInfo> pci) const
+{
     // Add joint velocity cost (without time) to penalize longer paths.
     auto jv = std::make_shared<JointVelTermInfo>();
     jv->targets = std::vector<double>(pci->kin->numJoints(), 0.0);

--- a/robowflex_tesseract/src/trajopt_planner.cpp
+++ b/robowflex_tesseract/src/trajopt_planner.cpp
@@ -421,9 +421,7 @@ TrajOptPlanner::PlannerResult TrajOptPlanner::plan(const SceneConstPtr &scene, c
 TrajOptPlanner::PlannerResult TrajOptPlanner::plan(const SceneConstPtr &scene,
                                                    const robot_state::RobotStatePtr &start_state)
 {
-    RBX_ERROR("You need to implement virtual method TrajOptPlanner::plan() in your derived class");
-
-    return PlannerResult(false, false);
+    throw Exception(1, "You need to implement virtual method TrajOptPlanner::plan() in your derived class");
 }
 
 std::vector<std::string> TrajOptPlanner::getPlannerConfigs() const


### PR DESCRIPTION
- It is now possible to inherit from the TrajOptPlanner class and override a plan() method. By doing this, the user can add custom terms (costs or constraints) into the trajectory optimization problem.
- The joint velocity cost is now incorporated in the new method addVelocityCost(). It used to be added in ProblemConstructionInfo() but since now the user can create custom problems, it is more convenient that everything is separated.
- A new script that shows how a user can create a custom trajopt planner for a UR5 robot and use it to add cartesian constraints for the end-effector for motion planning. The result is shown in the figure below:

![custom_trajopt_planner](https://user-images.githubusercontent.com/12850445/127406296-da01bbfc-d286-4318-b0da-f588ad227e9e.png)
