### PR TITLE
Fix narrowing conversion of ‘-1’ from ‘int’ to ‘uint32_t’ warning

### DIFF
--- a/robowflex_library/include/robowflex_library/benchmarking.h
+++ b/robowflex_library/include/robowflex_library/benchmarking.h
@@ -218,7 +218,7 @@ namespace robowflex
          */
         struct Options
         {
-            uint32_t metrics{~0};  ///< Bitmask of which metrics to compute after planning.
+            uint32_t metrics{0xffffffff};  ///< Bitmask of which metrics to compute after planning.
             bool progress{true};   ///< If true, captures planner progress properties (if they exist).
             bool progress_at_least_once{true};  ///< If true, will always run the progress loop at least once.
             double progress_update_rate{0.1};   ///< Update rate for progress callbacks.

--- a/robowflex_library/include/robowflex_library/benchmarking.h
+++ b/robowflex_library/include/robowflex_library/benchmarking.h
@@ -219,7 +219,7 @@ namespace robowflex
         struct Options
         {
             uint32_t metrics{0xffffffff};  ///< Bitmask of which metrics to compute after planning.
-            bool progress{true};   ///< If true, captures planner progress properties (if they exist).
+            bool progress{true};           ///< If true, captures planner progress properties (if they exist).
             bool progress_at_least_once{true};  ///< If true, will always run the progress loop at least once.
             double progress_update_rate{0.1};   ///< Update rate for progress callbacks.
         };


### PR DESCRIPTION
Unfortunately, some compilers don't seem to like the ~0 initialization for uint32_t and produce a warning; this change makes the setting of all bits to 1 explicit and silences the warning.