### PR TITLE
Goal marker without builder

### DIFF
--- a/robowflex_library/include/robowflex_library/benchmarking.h
+++ b/robowflex_library/include/robowflex_library/benchmarking.h
@@ -218,7 +218,7 @@ namespace robowflex
          */
         struct Options
         {
-            uint32_t metrics{~0};  ///< Bitmask of which metrics to compute after planning.
+            uint32_t metrics{0xffffffff};  ///< Bitmask of which metrics to compute after planning.
             bool progress{true};   ///< If true, captures planner progress properties (if they exist).
             bool progress_at_least_once{true};  ///< If true, will always run the progress loop at least once.
             double progress_update_rate{0.1};   ///< Update rate for progress callbacks.

--- a/robowflex_library/include/robowflex_library/benchmarking.h
+++ b/robowflex_library/include/robowflex_library/benchmarking.h
@@ -219,7 +219,7 @@ namespace robowflex
         struct Options
         {
             uint32_t metrics{0xffffffff};  ///< Bitmask of which metrics to compute after planning.
-            bool progress{true};   ///< If true, captures planner progress properties (if they exist).
+            bool progress{true};           ///< If true, captures planner progress properties (if they exist).
             bool progress_at_least_once{true};  ///< If true, will always run the progress loop at least once.
             double progress_update_rate{0.1};   ///< Update rate for progress callbacks.
         };

--- a/robowflex_library/include/robowflex_library/io/visualization.h
+++ b/robowflex_library/include/robowflex_library/io/visualization.h
@@ -193,6 +193,13 @@ namespace robowflex
              */
             void addGoalMarker(const std::string &name, const MotionRequestBuilder &request);
 
+            /** \brief Adds the current goal of the motion plan request  as a
+             * set of markers in the marker array.
+             *  \param[in] name Name of the marker(s).
+             *  \param[in] request Request to add goal of as a marker.
+             */
+            void addGoalMarker(const std::string &name, const moveit_msgs::MotionPlanRequest &request);
+
             /** \brief Removes all markers that were added through addMarker().
              */
             void removeAllMarkers();

--- a/robowflex_library/src/io/visualization.cpp
+++ b/robowflex_library/src/io/visualization.cpp
@@ -305,9 +305,9 @@ void IO::RVIZHelper::addGeometryMarker(const std::string &name, const GeometryCo
     addMarker(marker, name);
 }
 
-void IO::RVIZHelper::addGoalMarker(const std::string &name, const MotionRequestBuilder &request)
+void IO::RVIZHelper::addGoalMarker(const std::string &name, const moveit_msgs::MotionPlanRequest &request)
 {
-    const auto &goals = request.getRequestConst().goal_constraints;
+    const auto &goals = request.goal_constraints;
 
     // Iterate over each goal (an "or"-ing together of different constraints)
     for (const auto &goal : goals)
@@ -351,7 +351,7 @@ void IO::RVIZHelper::addGoalMarker(const std::string &name, const MotionRequestB
                     // Arrow display frame.
                     RobotPose qframe = RobotPose::Identity();
                     qframe.translate(frame.translation());  // Place arrows at the origin
-                                                            // of the position volume
+                    // of the position volume
 
                     Eigen::Vector3d scale = {0.1, 0.008, 0.003};  // A nice default size of arrow
 
@@ -390,6 +390,11 @@ void IO::RVIZHelper::addGoalMarker(const std::string &name, const MotionRequestB
             // }
         }
     }
+}
+
+void IO::RVIZHelper::addGoalMarker(const std::string &name, const MotionRequestBuilder &request)
+{
+    addGoalMarker(name, request.getRequestConst());
 }
 
 void IO::RVIZHelper::removeAllMarkers()


### PR DESCRIPTION
Added an overloaded version of `IO::RVIZHelper::addGoalMarker` that does not require a builder, and instead takes a request directly.

Note: this branch includes #238, might want to merge that one first. (I'll try my best to avoid dependencies like that from now on, am still learning branching strategies.)