### PR TITLE
Added direct access to underlying OMPL interface

### DIFF
--- a/robowflex_library/include/robowflex_library/benchmarking.h
+++ b/robowflex_library/include/robowflex_library/benchmarking.h
@@ -218,7 +218,7 @@ namespace robowflex
          */
         struct Options
         {
-            uint32_t metrics{~0};  ///< Bitmask of which metrics to compute after planning.
+            uint32_t metrics{0xffffffff};  ///< Bitmask of which metrics to compute after planning.
             bool progress{true};   ///< If true, captures planner progress properties (if they exist).
             bool progress_at_least_once{true};  ///< If true, will always run the progress loop at least once.
             double progress_update_rate{0.1};   ///< Update rate for progress callbacks.

--- a/robowflex_library/include/robowflex_library/benchmarking.h
+++ b/robowflex_library/include/robowflex_library/benchmarking.h
@@ -219,7 +219,7 @@ namespace robowflex
         struct Options
         {
             uint32_t metrics{0xffffffff};  ///< Bitmask of which metrics to compute after planning.
-            bool progress{true};   ///< If true, captures planner progress properties (if they exist).
+            bool progress{true};           ///< If true, captures planner progress properties (if they exist).
             bool progress_at_least_once{true};  ///< If true, will always run the progress loop at least once.
             double progress_update_rate{0.1};   ///< Update rate for progress callbacks.
         };

--- a/robowflex_ompl/include/robowflex_ompl/ompl_interface.h
+++ b/robowflex_ompl/include/robowflex_ompl/ompl_interface.h
@@ -89,6 +89,10 @@ namespace robowflex
             void preRun(const SceneConstPtr &scene,
                         const planning_interface::MotionPlanRequest &request) override;
 
+            /** \brief Access the OMPLInterface directly, to customize the planning process.
+             */
+            ompl_interface::OMPLInterface &getInterface() const;
+
         private:
             std::unique_ptr<ompl_interface::OMPLInterface> interface_{nullptr};  ///< Planning interface.
             std::vector<std::string> configs_;                                   ///< Planning configurations.

--- a/robowflex_ompl/src/ompl_interface.cpp
+++ b/robowflex_ompl/src/ompl_interface.cpp
@@ -141,3 +141,12 @@ std::vector<std::string> OMPL::OMPLInterfacePlanner::getPlannerConfigs() const
 {
     return configs_;
 }
+
+ompl_interface::OMPLInterface &OMPL::OMPLInterfacePlanner::getInterface() const
+{
+    if (!interface_)
+    {
+        RBX_WARN("Interface is not initialized before call to OMPLInterfacePlanner::initialize.");
+    }
+    return *interface_;
+}


### PR DESCRIPTION
I found that I needed to add custom goal samplers; this required access to the underlying OMPL interface.

This one also depends on #238, but is separate from #242 (I'm starting to figure that out).

Does this comply with the code style that you had in mind? The "warning if not initialized" is kinda ugly, but I don't see how to avoid that without a RAII-style planner class.