### PR TITLE
Flexible DART state space specification

### DIFF
--- a/robowflex_dart/include/robowflex_dart/joints.h
+++ b/robowflex_dart/include/robowflex_dart/joints.h
@@ -83,10 +83,25 @@ namespace robowflex
              */
             const std::vector<std::size_t> &getIndices() const;
 
+            /** \brief Get the names of the DoF in the skeleton for this joint.
+             *  \return Names of joint DoFs.
+             */
+            const std::vector<std::string> &getDofs() const;
+
             /** \brief Get the index of the skeleton for this joint in the world.
              *  \return Skeleton index.
              */
             std::size_t getSkeletonIndex() const;
+
+            /** \brief Get the index of the joint in the skeleton.
+             *  \return Joint index.
+             */
+            std::size_t getJointIndex() const;
+
+            /** \brief Get the dimension of this joint.
+             *  \return The dimension of the joint.
+             */
+            std::size_t getDimension() const;
 
             /** \} */
 
@@ -190,6 +205,7 @@ namespace robowflex
             ompl::RNG &rng_;     ///< Random number generator.
 
             std::vector<std::size_t> indices_;  ///< Indices this joint corresponds to.
+            std::vector<std::string> dofs_;     ///< Controlled DoF names.
 
             unsigned int skelIndex_;   ///< Index of skeleton.
             unsigned int jointIndex_;  ///< Index of joint.

--- a/robowflex_dart/include/robowflex_dart/space.h
+++ b/robowflex_dart/include/robowflex_dart/space.h
@@ -96,6 +96,15 @@ namespace robowflex
              */
             void addGroup(const std::string &name, const std::string &group, std::size_t cyclic = 0);
 
+            /** \brief Add a group to be planned for.
+             *  \param[in] group_name Name of the new group.
+             *  \param[in] joints Joints to add to this group.
+             *  \param[in] cyclic If >0, will flatten rotational groups (i.e., SO(2), SO(3)) into Rn spaces.
+             */
+            void addGroupFromJoints(const std::string &group_name,
+                                    const std::vector<dart::dynamics::Joint *> &joints,
+                                    std::size_t cyclic = 0);
+
             /** \} */
 
             /** \name World State
@@ -105,13 +114,13 @@ namespace robowflex
              *  \param[out] world World to set state of.
              *  \param[in] state State to set world.
              */
-            void setWorldState(WorldPtr world, const ompl::base::State *state);
+            void setWorldState(WorldPtr world, const ompl::base::State *state) const;
 
             /** \brief Set the state of a world from a configuration
              *  \param[out] world World to set state of.
              *  \param[in] x Configuration to set world.
              */
-            void setWorldState(WorldPtr world, const Eigen::Ref<const Eigen::VectorXd> &x);
+            void setWorldState(WorldPtr world, const Eigen::Ref<const Eigen::VectorXd> &x) const;
 
             /** \brief Get the state of a world in an OMPL state.
              *  \param[in] world World to get state of.
@@ -124,6 +133,22 @@ namespace robowflex
              *  \param[out] x Configuration to fill.
              */
             void getWorldState(WorldPtr world, Eigen::Ref<Eigen::VectorXd> x) const;
+
+            /** \brief Set the state of a world from a configuration of a group.
+             *  \param[out] world World to set state of.
+             *  \param[in] group_name Name of group to set.
+             *  \param[in] x Configuration to set.
+             */
+            void setWorldGroupState(WorldPtr world, const std::string &group_name,
+                                    const Eigen::Ref<const Eigen::VectorXd> &x) const;
+
+            /** \brief Get the group state of a world.
+             *  \param[in] world World to get state of.
+             *  \param[in] group_name Name of group to get.
+             *  \param[out] x Configuration to get.
+             */
+            void getWorldGroupState(WorldPtr world, const std::string &group_name,
+                                    Eigen::Ref<Eigen::VectorXd> x) const;
 
             /** \} */
 
@@ -171,6 +196,37 @@ namespace robowflex
              */
             const std::vector<JointPtr> &getJoints() const;
 
+            /** \brief From a full state, get only the state of a group.
+             *  \param[in] group The group to get the state for.
+             *  \param[in] state The state to get the group state from.
+             *  \param[out] v The group state to set.
+             */
+            void getGroupState(const std::string &group, const ompl::base::State *state,
+                               Eigen::Ref<Eigen::VectorXd> v) const;
+
+            /** \brief Set a (sub)group state in a full state.
+             *  \param[in] group The group to set the state for.
+             *  \param[out] state The state to set the group state in.
+             *  \param[in] v The group state to use.
+             */
+            void setGroupState(const std::string &group, ompl::base::State *state,
+                               const Eigen::Ref<const Eigen::VectorXd> &v) const;
+
+            /** \brief Get the dimension of joint variables for a subgroup.
+             *  \return The group's dimension.
+             */
+            std::size_t getGroupDimension(const std::string &group) const;
+
+            /** \brief Get the names of all groups managed by this space.
+             *  \return Names of all the groups.
+             */
+            std::vector<std::string> getGroups() const;
+
+            /** \brief Get the names of each of the dof controlled by a group.
+             *  \return The names of all the controlled dof for a group.
+             */
+            std::vector<std::string> getGroupDofNames(const std::string &group_name) const;
+
             /** \} */
 
             /** \name OMPL StateSpace Methods
@@ -193,11 +249,10 @@ namespace robowflex
             void setMetricSpace(bool metric);
 
         protected:
-            WorldPtr world_;  ///< World to use for planning.
+            void addJoint(const std::string &group_name, const JointPtr &joint);
+            void addJointToGroup(const std::string &group_name, const JointPtr &joint);
 
-            /** \brief Set of groups used in planning. Tuple of robot name, group, and cyclic count.
-             */
-            std::vector<std::tuple<std::string, std::string, std::size_t>> groups_;
+            WorldPtr world_;  ///< World to use for planning.
 
             std::set<dart::dynamics::Joint *> jointset_;  ///< Set of joints used in planning.
             std::vector<std::size_t> indices_;            ///< Vector of indices for planning.
@@ -207,6 +262,9 @@ namespace robowflex
             std::vector<JointPtr> joints_;  ///< Vector of all joints used in planning.
 
             ompl::RNG rng_;  ///< Random number generator.
+
+            std::map<std::string, std::vector<JointPtr>> group_joints_;  ///< Joints belonging to a group.
+            std::map<std::string, std::size_t> group_dimension_;         ///< Dimension of the group.
         };
     }  // namespace darts
 }  // namespace robowflex

--- a/robowflex_dart/src/joints/joint.cpp
+++ b/robowflex_dart/src/joints/joint.cpp
@@ -41,6 +41,7 @@ Joint::Joint(StateSpace *space,         //
 
         auto *dof = joint->getDof(i);
         indices_.emplace_back(dof->getIndexInSkeleton());
+        dofs_.emplace_back(dof->getName());
     }
 }
 
@@ -76,9 +77,24 @@ const std::vector<std::size_t> &Joint::getIndices() const
     return indices_;
 }
 
+const std::vector<std::string> &Joint::getDofs() const
+{
+    return dofs_;
+}
+
 std::size_t Joint::getSkeletonIndex() const
 {
     return skelIndex_;
+}
+
+std::size_t Joint::getJointIndex() const
+{
+    return jointIndex_;
+}
+
+std::size_t Joint::getDimension() const
+{
+    return numDof_;
 }
 
 void Joint::setJointState(WorldPtr world, const Eigen::Ref<const Eigen::VectorXd> &a) const

--- a/robowflex_dart/src/space.cpp
+++ b/robowflex_dart/src/space.cpp
@@ -154,7 +154,7 @@ void StateSpace::addGroupFromJoints(const std::string &group_name,
                 {
                     low[i] =
                         std::max({free->getPositionLowerLimit(3 + i), world_->getWorkspaceLowConst()[i]});
-                    high[i =
+                    high[i] =
                         std::min({free->getPositionUpperLimit(3 + i), world_->getWorkspaceHighConst()[i]});
                 }
 

--- a/robowflex_dart/src/space.cpp
+++ b/robowflex_dart/src/space.cpp
@@ -72,13 +72,20 @@ void StateSpace::addGroup(const std::string &name, const std::string &group, std
     }
 
     auto joints = robot->getGroupJoints(group);
+    addGroupFromJoints(group, joints, cyclic);
+}
 
-    groups_.emplace_back(name, group, cyclic);
+void StateSpace::addGroupFromJoints(const std::string &group_name,
+                                    const std::vector<dart::dynamics::Joint *> &joints, std::size_t cyclic)
+{
+    group_joints_.emplace(group_name, std::vector<JointPtr>{});
+    group_dimension_.emplace(group_name, 0);
+
     for (auto *joint : joints)
     {
         if (jointset_.find(joint) != jointset_.end())
         {
-            RBX_INFO("Joint %1% already being planned, skipping...", joint->getName());
+            addJointToGroup(group_name, getJoint(joint->getName()));
             continue;
         }
 
@@ -95,19 +102,16 @@ void StateSpace::addGroup(const std::string &name, const std::string &group, std
                 {
                     double low = -constants::pi * cyclic;
                     double high = constants::pi * cyclic;
-                    joints_.emplace_back(std::make_shared<RnJoint>(this, revolute, low, high));
+                    addJoint(group_name, std::make_shared<RnJoint>(this, revolute, low, high));
                 }
                 else
-                {
-                    joints_.emplace_back(std::make_shared<SO2Joint>(this, revolute));
-                    metric_ = false;
-                }
+                    addJoint(group_name, std::make_shared<SO2Joint>(this, revolute));
             }
             else
             {
                 auto *dof = joint->getDof(0);
                 auto limits = dof->getPositionLimits();
-                joints_.emplace_back(std::make_shared<RnJoint>(this, revolute, limits.first, limits.second));
+                addJoint(group_name, std::make_shared<RnJoint>(this, revolute, limits.first, limits.second));
             }
         }
         else if (type == "PrismaticJoint")
@@ -115,7 +119,7 @@ void StateSpace::addGroup(const std::string &name, const std::string &group, std
             auto *prismatic = static_cast<dart::dynamics::PrismaticJoint *>(joint);
             auto *dof = joint->getDof(0);
             auto limits = dof->getPositionLimits();
-            joints_.emplace_back(std::make_shared<RnJoint>(this, prismatic, limits.first, limits.second));
+            addJoint(group_name, std::make_shared<RnJoint>(this, prismatic, limits.first, limits.second));
         }
         else if (type == "FreeJoint")
         {
@@ -138,8 +142,8 @@ void StateSpace::addGroup(const std::string &name, const std::string &group, std
                     high[3 + i] =
                         std::min({free->getPositionUpperLimit(3 + i), world_->getWorkspaceHighConst()[i]});
                 }
-
-                joints_.emplace_back(std::make_shared<RnJoint>(this, free, 6, 0, low, high));
+                auto j = std::make_shared<RnJoint>(this, free, 6, 0, low, high);
+                addJoint(group_name, j);
             }
             else
             {
@@ -150,14 +154,12 @@ void StateSpace::addGroup(const std::string &name, const std::string &group, std
                 {
                     low[i] =
                         std::max({free->getPositionLowerLimit(3 + i), world_->getWorkspaceLowConst()[i]});
-                    high[i] =
+                    high[i =
                         std::min({free->getPositionUpperLimit(3 + i), world_->getWorkspaceHighConst()[i]});
                 }
 
-                joints_.emplace_back(std::make_shared<RnJoint>(this, free, 3, 3, low, high));
-                joints_.emplace_back(std::make_shared<SO3Joint>(this, free));
-
-                metric_ = false;
+                addJoint(group_name, std::make_shared<RnJoint>(this, free, 3, 3, low, high));
+                addJoint(group_name, std::make_shared<SO3Joint>(this, free));
             }
         }
         else
@@ -168,13 +170,28 @@ void StateSpace::addGroup(const std::string &name, const std::string &group, std
         std::make_shared<ompl::base::RealVectorRandomLinearProjectionEvaluator>(this, 2));
 }
 
-void StateSpace::setWorldState(WorldPtr world, const ompl::base::State *state)
+void StateSpace::addJoint(const std::string &group_name, const JointPtr &joint)
+{
+    joints_.emplace_back(joint);
+    addJointToGroup(group_name, joint);
+
+    if (not std::dynamic_pointer_cast<RnJoint>(joint))
+        metric_ = false;
+}
+
+void StateSpace::addJointToGroup(const std::string &group_name, const JointPtr &joint)
+{
+    group_joints_[group_name].emplace_back(joint);
+    group_dimension_[group_name] += joint->getDimension();
+}
+
+void StateSpace::setWorldState(WorldPtr world, const ompl::base::State *state) const
 {
     const auto &as = state->as<StateType>();
     setWorldState(std::move(world), as->data);
 }
 
-void StateSpace::setWorldState(WorldPtr world, const Eigen::Ref<const Eigen::VectorXd> &x)
+void StateSpace::setWorldState(WorldPtr world, const Eigen::Ref<const Eigen::VectorXd> &x) const
 {
     for (const auto &joint : joints_)
     {
@@ -197,6 +214,36 @@ void StateSpace::getWorldState(WorldPtr world, Eigen::Ref<Eigen::VectorXd> x) co
     {
         const auto &v = joint->getSpaceVars(x);
         joint->getJointState(world, v);
+    }
+}
+
+void StateSpace::setWorldGroupState(WorldPtr world, const std::string &group_name,
+                                    const Eigen::Ref<const Eigen::VectorXd> &x) const
+{
+    const auto &joints = group_joints_.find(group_name)->second;
+
+    std::size_t index = 0;
+    for (const auto &joint : joints)
+    {
+        std::size_t n = joint->getDimension();
+        joint->setJointState(world, x.segment(index, n));
+        index += n;
+    }
+
+    world->forceUpdate();
+}
+
+void StateSpace::getWorldGroupState(WorldPtr world, const std::string &group_name,
+                                    Eigen::Ref<Eigen::VectorXd> x) const
+{
+    const auto &joints = group_joints_.find(group_name)->second;
+
+    std::size_t index = 0;
+    for (const auto &joint : joints)
+    {
+        std::size_t n = joint->getDimension();
+        joint->getJointState(world, x.segment(index, n));
+        index += n;
     }
 }
 
@@ -328,6 +375,64 @@ JointPtr StateSpace::getJoint(const std::string &name) const
 const std::vector<JointPtr> &StateSpace::getJoints() const
 {
     return joints_;
+}
+
+void StateSpace::getGroupState(const std::string &group, const ompl::base::State *state,
+                               Eigen::Ref<Eigen::VectorXd> v) const
+{
+    const auto &joints = group_joints_.find(group)->second;
+    const auto &as = state->as<StateType>();
+
+    std::size_t index = 0;
+    for (const auto &joint : joints)
+    {
+        std::size_t n = joint->getDimension();
+        v.segment(index, n) = joint->getSpaceVarsConst(as->data);
+        index += n;
+    }
+}
+
+void StateSpace::setGroupState(const std::string &group, ompl::base::State *state,
+                               const Eigen::Ref<const Eigen::VectorXd> &v) const
+{
+    const auto &joints = group_joints_.find(group)->second;
+    auto *as = state->as<StateType>();
+
+    std::size_t index = 0;
+    for (const auto &joint : joints)
+    {
+        std::size_t n = joint->getDimension();
+        joint->getSpaceVars(as->data) = v.segment(index, n);
+        index += n;
+    }
+}
+
+std::size_t StateSpace::getGroupDimension(const std::string &group) const
+{
+    return group_dimension_.find(group)->second;
+}
+
+std::vector<std::string> StateSpace::getGroups() const
+{
+    std::vector<std::string> groups;
+    for (const auto &pair : group_joints_)
+        groups.emplace_back(pair.first);
+
+    return groups;
+}
+
+std::vector<std::string> StateSpace::getGroupDofNames(const std::string &group_name) const
+{
+    std::vector<std::string> dofs;
+
+    const auto &joints = group_joints_.find(group_name)->second;
+    for (const auto &joint : joints)
+    {
+        const auto &jdofs = joint->getDofs();
+        dofs.insert(dofs.end(), jdofs.begin(), jdofs.end());
+    }
+
+    return dofs;
 }
 
 Eigen::VectorXd StateSpace::getLowerBound() const


### PR DESCRIPTION
Adds `addGroupFromJoints`, which allows for a more flexible specification of which joints to plan for in the DART state space.