### PR TITLE
Added robot state reference goal configuration setter

### DIFF
--- a/robowflex_library/include/robowflex_library/builder.h
+++ b/robowflex_library/include/robowflex_library/builder.h
@@ -137,9 +137,16 @@ namespace robowflex
         void setGoalConfiguration(const std::vector<double> &joints);
 
         /** \brief Set the goal configuration from a robot state.
-         *  \param[in] state The robot state to set. Usually from robowflex::Robot::getScratchState().
+         *  \param[in] state The robot state to set as a pointer. Usually from
+         * robowflex::Robot::getScratchState().
          */
         void setGoalConfiguration(const robot_state::RobotStatePtr &state);
+
+        /** \brief Set the goal configuration from a robot state.
+         *  \param[in] state The robot state to set as a reference. Usually from
+         * robowflex::Robot::getScratchState().
+         */
+        void setGoalConfiguration(const robot_state::RobotState &state);
 
         /** \brief Set the goal pose from an IK query.
          *  \param[in] query IK query to construct goal from.

--- a/robowflex_library/src/builder.cpp
+++ b/robowflex_library/src/builder.cpp
@@ -223,6 +223,11 @@ void MotionRequestBuilder::setGoalConfiguration(const std::vector<double> &joint
 
 void MotionRequestBuilder::setGoalConfiguration(const robot_state::RobotStatePtr &state)
 {
+    setGoalConfiguration(*state);
+}
+
+void MotionRequestBuilder::setGoalConfiguration(const robot_state::RobotState &state)
+{
     if (not jmg_)
     {
         RBX_ERROR("No planning group set!");
@@ -230,7 +235,7 @@ void MotionRequestBuilder::setGoalConfiguration(const robot_state::RobotStatePtr
     }
 
     incrementVersion();
-    request_.goal_constraints.push_back(kinematic_constraints::constructGoalConstraints(*state, jmg_));
+    request_.goal_constraints.push_back(kinematic_constraints::constructGoalConstraints(state, jmg_));
 }
 
 void MotionRequestBuilder::setGoalFromIKQuery(const Robot::IKQuery &query)


### PR DESCRIPTION
Noticed that there wasn't a version of robowflex::MotionRequestBuilder::setGoalConfiguation that accepted a reference to a robot state. 

In the original version that accepted a pointer, the pointer was dereferenced before use. I changed the original method to accept a reference and created a pointer version that dereferences the robot state and passes it.