### PR TITLE
[WIP] Added a callback member to the OMPL planner.

### DIFF
--- a/robowflex_ompl/include/robowflex_ompl/ompl_interface.h
+++ b/robowflex_ompl/include/robowflex_ompl/ompl_interface.h
@@ -8,6 +8,8 @@
 #include <robowflex_library/class_forward.h>
 #include <robowflex_library/planning.h>
 
+#include <functional>
+
 namespace robowflex
 {
     /** \cond IGNORE */
@@ -93,6 +95,12 @@ namespace robowflex
              */
             ompl_interface::OMPLInterface &getInterface() const;
 
+            /** \brief Set a callback, to be called right before a planning session for last-minute configuration or external bookkeeping.
+             *
+             * refreshContext() will already have been called, so the SimpleSetup obtained by getLastSimpleSetup() will be the one used for planning.
+             */
+            void setPreplanCallback(const std::function<void()> &preplanCallback);
+
         private:
             std::unique_ptr<ompl_interface::OMPLInterface> interface_{nullptr};  ///< Planning interface.
             std::vector<std::string> configs_;                                   ///< Planning configurations.
@@ -105,6 +113,9 @@ namespace robowflex
             mutable ompl_interface::ModelBasedPlanningContextPtr context_;  ///< Last context.
             mutable ompl::geometric::SimpleSetupPtr ss_;  ///< Last OMPL simple setup used for
                                                           ///< planning.
+
+            std::function<void()> preplan_callback_;
+
         };
     }  // namespace OMPL
 }  // namespace robowflex

--- a/robowflex_ompl/src/ompl_interface.cpp
+++ b/robowflex_ompl/src/ompl_interface.cpp
@@ -66,6 +66,8 @@ planning_interface::MotionPlanResponse OMPL::OMPLInterfacePlanner::plan(
     if (not ss_)
         return response;
 
+    preplan_callback_();
+
     context_->solve(response);
     return response;
 }
@@ -149,4 +151,8 @@ ompl_interface::OMPLInterface &OMPL::OMPLInterfacePlanner::getInterface() const
         RBX_WARN("Interface is not initialized before call to OMPLInterfacePlanner::initialize.");
     }
     return *interface_;
+}
+
+void OMPL::OMPLInterfacePlanner::setPreplanCallback(const std::function<void()> &preplanCallback) {
+    preplan_callback_ = preplanCallback;
 }


### PR DESCRIPTION
Proposed solution to #254: I've added a callback to the OMPL planner that gets called just before planning actually takes place, after the context has been refreshed. This allows the user to directly access the SimpleSetup right before it gets used.

I figured that #254 wouldn't be the last time someone needed direct access to SimpleSetup, so this should make that a lot easier.

@zkingston Please review, though... You know the way this code works better than I do, and this change is a bit more than just adding an objective factory.