### PR TITLE
Added append method for trajectories

### DIFF
--- a/robowflex_library/include/robowflex_library/trajectory.h
+++ b/robowflex_library/include/robowflex_library/trajectory.h
@@ -166,6 +166,16 @@ namespace robowflex
          */
         std::vector<std::string> getJointNames() const;
 
+        /** \brief Adds a specified part of a trajectory to the end of the current trajectory. The default,
+         *  when \a start_index or \a end_index are ommitted, is to add the whole trajectory.
+         *  \param[in] source The trajectory containing the part to append to the end of current trajectory.
+         *  \param[in] dt Time step between last point in current traj and first point of append traj.
+         *  \param[in] start_index Index of first traj point of the part to append from the source traj.
+         *  \param[in] end_index Index of last traj point of the part to append from the source traj.
+         */
+        Trajectory &append(const Trajectory &source, double dt, size_t start_index = 0,
+                           size_t end_index = std::numeric_limits<std::size_t>::max());
+
         /** \} */
 
         /** \name Metrics

--- a/robowflex_library/src/trajectory.cpp
+++ b/robowflex_library/src/trajectory.cpp
@@ -169,6 +169,12 @@ std::vector<std::string> Trajectory::getJointNames() const
     return getMessage().joint_trajectory.joint_names;
 }
 
+Trajectory &Trajectory::append(const Trajectory &source, double dt, size_t start_index, size_t end_index)
+{
+    trajectory_->append(*source.getTrajectoryConst(), dt, start_index, end_index);
+    return *this;
+}
+
 double Trajectory::getLength(const PathMetric &metric) const
 {
     double length = 0.0;
@@ -232,10 +238,9 @@ double Trajectory::getSmoothness(const PathMetric &metric) const
 {
     double smoothness = 0.0;
 
-    auto distance =
-        (metric) ? metric : [](const robot_state::RobotState &a, const robot_state::RobotState &b) {
-            return a.distance(b);
-        };
+    auto distance = (metric) ? metric :
+                               [](const robot_state::RobotState &a, const robot_state::RobotState &b)
+    { return a.distance(b); };
 
     // compute smoothness
     if (trajectory_->getWayPointCount() > 2)


### PR DESCRIPTION
Copied the method header for `moveit_core::robot_trajectory::RobotTrajectory::append` for Robowflex's trajectory.

Simply calls the append method for the internal moveit trajectory with the arguments provided. This was tested by appending several trajectories and visualizing the result in RViz. 