### PR TITLE
Added method overrides for visualizing multiple trajectories

### DIFF
--- a/robowflex_library/include/robowflex_library/io/visualization.h
+++ b/robowflex_library/include/robowflex_library/io/visualization.h
@@ -70,6 +70,8 @@ namespace robowflex
             void updateTrajectory(const moveit_msgs::RobotTrajectory &traj,
                                   const moveit::core::RobotState &start);
 
+            void updateTrajectories(const std::vector<robot_trajectory::RobotTrajectoryPtr> &trajectories);
+
             /** \brief Updates the trajectory being visualized to a list of trajectories.
              *  \param[in] responses Planning responses to visualize.
              */

--- a/robowflex_library/include/robowflex_library/io/visualization.h
+++ b/robowflex_library/include/robowflex_library/io/visualization.h
@@ -70,6 +70,9 @@ namespace robowflex
             void updateTrajectory(const moveit_msgs::RobotTrajectory &traj,
                                   const moveit::core::RobotState &start);
 
+            /** \brief Updates the trajectory being visualized to a list of trajectories.
+             *  \param[in] trajectories Vector of MoveIt! robot trajectories to visualize.
+             */
             void updateTrajectories(const std::vector<robot_trajectory::RobotTrajectoryPtr> &trajectories);
 
             /** \brief Updates the trajectory being visualized to a list of trajectories.

--- a/robowflex_library/include/robowflex_library/io/visualization.h
+++ b/robowflex_library/include/robowflex_library/io/visualization.h
@@ -75,6 +75,11 @@ namespace robowflex
              */
             void updateTrajectories(const std::vector<planning_interface::MotionPlanResponse> &responses);
 
+            /** \brief Updates the trajectory being visualized to a list of trajectories.
+             *  \param[in] responses Vector of robowflex trajectories to visualize.
+             */
+            void updateTrajectories(const std::vector<TrajectoryPtr> &trajectories);
+
             /** \} */
 
             /** \name States

--- a/robowflex_library/src/io/visualization.cpp
+++ b/robowflex_library/src/io/visualization.cpp
@@ -92,27 +92,23 @@ void IO::RVIZHelper::updateTrajectory(const moveit_msgs::RobotTrajectory &traj,
     trajectory_pub_.publish(out);
 }
 
-void IO::RVIZHelper::updateTrajectories(const std::vector<planning_interface::MotionPlanResponse> &responses)
+void IO::RVIZHelper::updateTrajectories(const std::vector<robot_trajectory::RobotTrajectoryPtr> &trajectories)
 {
     moveit_msgs::DisplayTrajectory out;
     out.model_id = robot_->getModelName();
 
     bool set = false;
-    for (const auto &response : responses)
+    for (const auto &traj : trajectories)
     {
         if (!set)
         {
-            moveit::core::robotStateToRobotStateMsg(response.trajectory_->getFirstWayPoint(),
-                                                    out.trajectory_start);
+            moveit::core::robotStateToRobotStateMsg(traj->getFirstWayPoint(), out.trajectory_start);
             set = true;
         }
 
-        if (response.error_code_.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
-        {
-            moveit_msgs::RobotTrajectory msg;
-            response.trajectory_->getRobotTrajectoryMsg(msg);
-            out.trajectory.push_back(msg);
-        }
+        moveit_msgs::RobotTrajectory msg;
+        traj->getRobotTrajectoryMsg(msg);
+        out.trajectory.push_back(msg);
     }
 
     if (trajectory_pub_.getNumSubscribers() < 1)
@@ -127,36 +123,31 @@ void IO::RVIZHelper::updateTrajectories(const std::vector<planning_interface::Mo
     trajectory_pub_.publish(out);
 }
 
+void IO::RVIZHelper::updateTrajectories(const std::vector<planning_interface::MotionPlanResponse> &responses)
+{
+    auto moveit_trajectories = std::vector<robot_trajectory::RobotTrajectoryPtr>();
+
+    for (const auto &response : responses)
+    {
+        if (response.error_code_.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
+        {
+            moveit_trajectories.push_back(response.trajectory_);
+        }
+    }
+
+    this->updateTrajectories(moveit_trajectories);
+}
+
 void IO::RVIZHelper::updateTrajectories(const std::vector<TrajectoryPtr> &trajectories)
 {
-    moveit_msgs::DisplayTrajectory out;
-    out.model_id = robot_->getModelName();
+    auto moveit_trajectories = std::vector<robot_trajectory::RobotTrajectoryPtr>();
 
-    bool set = false;
     for (const auto &traj : trajectories)
     {
-        if (!set)
-        {
-            moveit::core::robotStateToRobotStateMsg(traj->getTrajectory()->getFirstWayPoint(),
-                                                    out.trajectory_start);
-            set = true;
-        }
-
-        moveit_msgs::RobotTrajectory msg;
-        traj->getTrajectory()->getRobotTrajectoryMsg(msg);
-        out.trajectory.push_back(msg);
+        moveit_trajectories.push_back(traj->getTrajectory());
     }
 
-    if (trajectory_pub_.getNumSubscribers() < 1)
-    {
-        RBX_INFO("Waiting for Trajectory subscribers...");
-
-        ros::WallDuration pause(0.1);
-        while (trajectory_pub_.getNumSubscribers() < 1)
-            pause.sleep();
-    }
-
-    trajectory_pub_.publish(out);
+    this->updateTrajectories(moveit_trajectories);
 }
 
 void IO::RVIZHelper::visualizeState(const robot_state::RobotStatePtr &state)


### PR DESCRIPTION
Noticed that the already existing version of `RVizHelper::updateTrajectories` actually used the MoveIt! trajectories under the hood. I've been working with vectors of Robowflex trajectories and thought it'd be useful to be able to visualize those too.

I created a base method that implemented the same logic as the previous version but accepted vectors of MoveIt! trajectories. The method overrides that accept different types convert their vector form and call the base method. 

I made sure to maintain the behavior that invalid motion plans would not be added for the method accepting vectors of `MotionPlanResponse`.