### PR TITLE
Adding projects that depend on robowflex

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,7 @@ rosrun robowflex_library fetch_test
 ## Code Formatting
 All C++ code should be formatted with `clang-format`.
 Use the `format.sh` script to automatically format the code base.
+
+## Applications 
+External Project that make use of Robowflex:
+- Learning and Motion Planning Algorithms: https://github.com/KavrakiLab/pyre


### PR DESCRIPTION
As we have discussed I think it would be a good idea to have open-sourced projects that depend on robowflex be listed on the website to highlight use-cases. 