### PR TITLE
Optimization Objective Setters in OMPL Interface

### DIFF
--- a/robowflex_ompl/include/robowflex_ompl/ompl_interface.h
+++ b/robowflex_ompl/include/robowflex_ompl/ompl_interface.h
@@ -115,7 +115,33 @@ namespace robowflex
              */
             void setPrePlanCallback(const PrePlanCallback &prePlanCallback);
 
+            /** \brief Sets whether or not the planner should hybridize solutions.
+             *  \param[in] hybridize If true, planner will hybridize solutions.
+             */
+            void setHybridize(bool hybridize);
+
+            /** \brief Sets whether or not the planner should interpolate solutions.
+             *  \param[in] interpolate If true, planner will interpolate solutions.
+             */
+            void setInterpolate(bool interpolate);
+
+            /** \brief Sets default optimization objective to minimize path length.
+             */
+            void usePathLengthObjective();
+
+            /** \brief Sets default optimization objective to maximize the minimum path clearance.
+             */
+            void useMaxMinClearanceObjective();
+
         private:
+            /** \brief Optimization objectives for planning. */
+            enum Objective
+            {
+                PATH_LENGTH,       ///< Minimize path length objective.
+                MAX_MIN_CLEARANCE  ///< Maximize minimum clearance objective.
+            };
+
+            Objective objective_{PATH_LENGTH};  ///< Optimization objective to use.
             std::unique_ptr<ompl_interface::OMPLInterface> interface_{nullptr};  ///< Planning interface.
             std::vector<std::string> configs_;                                   ///< Planning configurations.
             bool hybridize_;    ///< Whether or not planner should hybridize solutions.

--- a/robowflex_ompl/src/ompl_interface.cpp
+++ b/robowflex_ompl/src/ompl_interface.cpp
@@ -1,3 +1,8 @@
+/* Author: Zachary Kingston */
+
+#include <ompl/base/objectives/PathLengthOptimizationObjective.h>
+#include <ompl/base/objectives/MaximizeMinClearanceObjective.h>
+
 #include <moveit/ompl_interface/model_based_planning_context.h>
 
 #include <robowflex_library/macros.h>
@@ -129,6 +134,21 @@ void OMPL::OMPLInterfacePlanner::refreshContext(const SceneConstPtr &scene,
 
     ss_ = context_->getOMPLSimpleSetup();
 
+    // Set desired default optimization objective
+    ompl::base::OptimizationObjectivePtr obj;
+    switch (objective_)
+    {
+        case MAX_MIN_CLEARANCE:
+            obj = std::make_shared<ompl::base::MaximizeMinClearanceObjective>(ss_->getSpaceInformation());
+            break;
+        case PATH_LENGTH:
+        default:
+            obj = std::make_shared<ompl::base::PathLengthOptimizationObjective>(ss_->getSpaceInformation());
+            break;
+    }
+
+    ss_->getProblemDefinition()->setOptimizationObjective(obj);
+
     last_scene_id_ = scene_id;
     last_request_hash_ = request_hash;
 
@@ -157,4 +177,24 @@ ompl_interface::OMPLInterface &OMPL::OMPLInterfacePlanner::getInterface() const
 void OMPL::OMPLInterfacePlanner::setPrePlanCallback(const PrePlanCallback &prePlanCallback)
 {
     pre_plan_callback_ = prePlanCallback;
+}
+
+void OMPL::OMPLInterfacePlanner::setHybridize(bool hybridize)
+{
+    hybridize_ = hybridize;
+}
+
+void OMPL::OMPLInterfacePlanner::setInterpolate(bool interpolate)
+{
+    interpolate_ = interpolate;
+}
+
+void OMPL::OMPLInterfacePlanner::usePathLengthObjective()
+{
+    objective_ = PATH_LENGTH;
+}
+
+void OMPL::OMPLInterfacePlanner::useMaxMinClearanceObjective()
+{
+    objective_ = MAX_MIN_CLEARANCE;
 }


### PR DESCRIPTION
Addresses https://github.com/KavrakiLab/kl_robots/issues/29 
Users should have:
1. setHybridize(true)
2. useMaxMinClearanceObjective()
3. Planning request with >1 planning attempts
This should have the planner optimize for maximizing the minimum clearance from obstacles.