### PR TITLE
Fix external validation bug with IK 

### DIFF
--- a/robowflex_library/scripts/baxter_multi_target.cpp
+++ b/robowflex_library/scripts/baxter_multi_target.cpp
@@ -9,11 +9,12 @@
 using namespace robowflex;
 
 /* \file baxter_multi_target.cpp
- * A script that demonstrates the multi-target IK query functionality with a baxter robot.  The
- * robowflex_resouces package needs to  be available, see https://github.com/KavrakiLab/robowflex_resources.
- * You should run RViz and have a RobotState visualization display enabled set to look at
- * /robowflex/robot_description, and robowflex/state. Also a MarkerArray should be added to visualize the
- * target IK poses.
+ * A script that demonstrates the multi-target IK query functionality with a
+ * baxter robot.  The robowflex_resouces package needs to  be available, see
+ * https://github.com/KavrakiLab/robowflex_resources. You should run RViz and
+ * have a RobotState visualization display enabled set to look at
+ * /robowflex/robot_description, and robowflex/state. Also a MarkerArray should
+ * be added to visualize the target IK poses.
  */
 
 static const std::string BOTH_ARMS = "both_arms";
@@ -51,6 +52,7 @@ int main(int argc, char **argv)
     std::cin.ignore();
 
     Robot::IKQuery query(BOTH_ARMS, {goal_pose_left, goal_pose_right}, {LEFT_EE, RIGHT_EE});
+
     if (not baxter->setFromIK(query))
     {
         RBX_ERROR("IK query failed!");
@@ -59,6 +61,60 @@ int main(int argc, char **argv)
 
     // Visualize resulting state.
     rviz.visualizeCurrentState();
+
+    // Need approximate solutions as multi-target BioIK will only return
+    // approximate solutions.
+    query.options.return_approximate_solution = true;
+    query.validate = true;        // Need external validation to verify approximate
+                                  // solutions are within tolerance.
+    query.valid_distance = 0.05;  // Tuned distance threshold that is appropriate for query.
+                                  //    query.verbose = true;
+
+    if (not baxter->setFromIK(query))
+    {
+        RBX_ERROR("Approximate IK query failed!");
+        return 1;
+    }
+
+    RBX_INFO("Robot IK solution visualized,  Press enter to continue...");
+    std::cin.ignore();
+
+    // Visualize resulting state.
+    rviz.visualizeCurrentState();
+
+    query = Robot::IKQuery("left_arm", {goal_pose_left}, {LEFT_EE});
+    if (not baxter->setFromIK(query))
+    {
+        RBX_ERROR("Single IK query failed!");
+        return 1;
+    }
+
+    RBX_INFO("Robot IK solution visualized,  Press enter to continue...");
+    std::cin.ignore();
+
+    // Visualize resulting state.
+    rviz.visualizeCurrentState();
+
+    // Need approximate solutions as multi-target BioIK will only return
+    // approximate solutions.
+    query.options.return_approximate_solution = true;
+    query.validate = true;        // Need external validation to verify approximate
+                                  // solutions are within tolerance.
+    query.valid_distance = 0.05;  // Tuned distance threshold that is appropriate for query.
+                                  //    query.verbose = true;
+
+    if (not baxter->setFromIK(query))
+    {
+        RBX_ERROR("Single Approximate IK query failed!");
+        return 1;
+    }
+
+    RBX_INFO("Robot IK solution visualized,  Press enter to continue...");
+    std::cin.ignore();
+
+    // Visualize resulting state.
+    rviz.visualizeCurrentState();
+
     RBX_INFO("Solution to IK is visualized. Press enter to exit...");
     std::cin.ignore();
 

--- a/robowflex_library/scripts/baxter_multi_target.cpp
+++ b/robowflex_library/scripts/baxter_multi_target.cpp
@@ -18,6 +18,7 @@ using namespace robowflex;
  */
 
 static const std::string BOTH_ARMS = "both_arms";
+static const std::string LEFT_ARM = "left_arm";
 static const std::string LEFT_EE = "left_gripper_base";
 static const std::string RIGHT_EE = "right_gripper_base";
 
@@ -62,46 +63,26 @@ int main(int argc, char **argv)
     // Visualize resulting state.
     rviz.visualizeCurrentState();
 
-    // Need approximate solutions as multi-target BioIK will only return
-    // approximate solutions.
-    query.options.return_approximate_solution = true;
-    query.validate = true;        // Need external validation to verify approximate
-                                  // solutions are within tolerance.
-    query.valid_distance = 0.05;  // Tuned distance threshold that is appropriate for query.
-                                  //    query.verbose = true;
-
-    if (not baxter->setFromIK(query))
-    {
-        RBX_ERROR("Approximate IK query failed!");
-        return 1;
-    }
-
     RBX_INFO("Robot IK solution visualized,  Press enter to continue...");
     std::cin.ignore();
 
-    // Visualize resulting state.
-    rviz.visualizeCurrentState();
-
-    query = Robot::IKQuery("left_arm", {goal_pose_left}, {LEFT_EE});
+    query = Robot::IKQuery(LEFT_ARM, goal_pose_left);
     if (not baxter->setFromIK(query))
     {
         RBX_ERROR("Single IK query failed!");
         return 1;
     }
 
-    RBX_INFO("Robot IK solution visualized,  Press enter to continue...");
-    std::cin.ignore();
-
     // Visualize resulting state.
     rviz.visualizeCurrentState();
 
-    // Need approximate solutions as multi-target BioIK will only return
-    // approximate solutions.
-    query.options.return_approximate_solution = true;
-    query.validate = true;        // Need external validation to verify approximate
-                                  // solutions are within tolerance.
+    RBX_INFO("Robot left arm IK(ee:default) is visualized. Press enter to continue ...");
+    std::cin.ignore();
+
+    query = Robot::IKQuery(LEFT_ARM, {goal_pose_left}, {LEFT_EE});
+    query.options.return_approximate_solution = true;  // Enable approximate IK solutions.
+    query.validate = true;        // Use to verify approximate solutions are within tolerance.
     query.valid_distance = 0.05;  // Tuned distance threshold that is appropriate for query.
-                                  //    query.verbose = true;
 
     if (not baxter->setFromIK(query))
     {
@@ -109,13 +90,9 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    RBX_INFO("Robot IK solution visualized,  Press enter to continue...");
-    std::cin.ignore();
-
     // Visualize resulting state.
     rviz.visualizeCurrentState();
-
-    RBX_INFO("Solution to IK is visualized. Press enter to exit...");
+    RBX_INFO("Robot left arm IK(ee:left_gripper_base) is visualized. Press enter to exit...");
     std::cin.ignore();
 
     return 0;

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -813,10 +813,10 @@ void Robot::IKQuery::getMessage(const std::string &base_frame, moveit_msgs::Cons
 kinematic_constraints::KinematicConstraintSetPtr Robot::IKQuery::getAsConstraints(const Robot &robot) const
 {
     moveit_msgs::Constraints msg;
-    getMessage(robot.getSolverBaseFrame(group), msg);
+    getMessage(robot.getModelConst()->getRootLink()->getName(), msg);
 
     auto constraints = std::make_shared<kinematic_constraints::KinematicConstraintSet>(robot.getModelConst());
-    moveit::core::Transforms none(robot.getModelConst()->getModelFrame());
+    moveit::core::Transforms none(robot.getModelConst()->getRootLink()->getName());
 
     constraints->add(msg, none);
 
@@ -838,8 +838,14 @@ bool Robot::setFromIK(const IKQuery &query)
     return setFromIK(query, *scratch_);
 }
 
-bool Robot::setFromIK(const IKQuery &query, robot_state::RobotState &state) const
+bool Robot::setFromIK(const IKQuery &q, robot_state::RobotState &state) const
 {
+    // copy query for unconstness
+    IKQuery query(q);
+
+    if (query.tips[0].empty())
+        query.tips = getSolverTipFrames(query.group);
+
     const robot_model::JointModelGroup *jmg = model_->getJointModelGroup(query.group);
     const auto &gsvcf =
         (query.scene) ? query.scene->getGSVCF(query.verbose) : moveit::core::GroupStateValidityCallbackFn{};
@@ -860,19 +866,12 @@ bool Robot::setFromIK(const IKQuery &query, robot_state::RobotState &state) cons
         query.sampleRegions(targets);
 
 #if ROBOWFLEX_AT_LEAST_MELODIC
-        // Multi-tip IK. Will delegate automatically to RobotState::setFromIKSubgroups() if the kinematics
+        // Multi-tip IK: Will delegate automatically to RobotState::setFromIKSubgroups() if the kinematics
         // solver doesn't support multi-tip queries.
-        if (targets.size() > 1)
-            success = state.setFromIK(jmg, targets, query.tips, query.timeout, gsvcf, query.options);
-        // Single-tip IK.
-        else
-            success = state.setFromIK(jmg, targets[0], query.timeout, gsvcf, query.options);
-
-#else  // attempts was a prior field that was deprecated in melodic
-        if (targets.size() > 1)
-            success = state.setFromIK(jmg, targets, query.tips, 1, query.timeout, gsvcf, query.options);
-        else
-            success = state.setFromIK(jmg, targets[0], 1, query.timeout, gsvcf, query.options);
+        success = state.setFromIK(jmg, targets, query.tips, query.timeout, gsvcf, query.options);
+#else
+        // attempts was a prior field that was deprecated in melodic
+        success = state.setFromIK(jmg, targets, query.tips, 1, query.timeout, gsvcf, query.options);
 #endif
 
         if (evaluate)


### PR DESCRIPTION
This PR does the following: 
* If a tip is not specified in the IK query the default one is added during [setFromIK()](https://kavrakilab.github.io/robowflex/robowflex__library_2src_2robot_8cpp_source.html#l00841). This allows validation to be used since the tip is now specified. Before it was unspecified resulting in an empty constraint that always returned true
* The same setFromIK function i used from MoveIT for both multi-tip and single-tip queries, this was one of the reasons why external validation was not working for  the baxter robot
* Adds the constraints of the external validation relative to the global frame instead of the first link of the chain. This was another reason why external validation was not working, since the pose constraints are always added relative to the global frame. 
* Modfiied the baxter IK script to illustrate different uses of IK, including single tip and approximate with validation