### PR TITLE
[WIP] Feature: Add Python bindings

### DIFF
--- a/robowflex_library/CMakeLists.txt
+++ b/robowflex_library/CMakeLists.txt
@@ -21,7 +21,6 @@ find_library(YAML yaml-cpp REQUIRED)
 find_package(TinyXML2 REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS C CXX)
-# find_package(Python COMPONENTS Interpreter Development)
 find_package(pybind11 CONFIG)
 
 ##
@@ -120,6 +119,7 @@ target_link_libraries(${LIBRARY_NAME} ${LIBRARIES})
 ##
 if(${pybind11_FOUND})
   pybind11_add_module(robowflex_library_python src/python_bindings.cpp)
+  set_target_properties(robowflex_library_python PROPERTIES OUTPUT_NAME "robowflex")
 endif()
 
 ##
@@ -164,3 +164,11 @@ add_test_script(robot_scene)
 install_scripts()
 install_library()
 install_directory(yaml)
+if(${pybind11_FOUND})
+  # We do this here because it causes errors with this old version of CMake if we do it before
+  # finding pybind11
+  find_package(Python COMPONENTS Development)
+  install(TARGETS robowflex_library_python
+    COMPONENT python
+    LIBRARY DESTINATION "${Python_SITELIB}/robowflex")
+endif()

--- a/robowflex_library/CMakeLists.txt
+++ b/robowflex_library/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 project(robowflex_library)
 
 set(LIBRARY_NAME ${PROJECT_NAME})
@@ -20,6 +21,8 @@ find_library(YAML yaml-cpp REQUIRED)
 find_package(TinyXML2 REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS C CXX)
+# find_package(Python COMPONENTS Interpreter Development)
+find_package(pybind11 CONFIG)
 
 ##
 ## Catkin setup
@@ -111,6 +114,13 @@ link_directories(${catkin_LIBRARY_DIRS})
 add_library(${LIBRARY_NAME} ${SOURCES})
 set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${LIBRARY_NAME} ${LIBRARIES})
+
+##
+## Python bindings
+##
+if(${pybind11_FOUND})
+  pybind11_add_module(robowflex_library_python src/python_bindings.cpp)
+endif()
 
 ##
 ## Scripts

--- a/robowflex_library/fetch_test.py
+++ b/robowflex_library/fetch_test.py
@@ -1,0 +1,65 @@
+from sys import argv
+
+import robowflex_library as rf
+
+GROUP = "arm_with_torso"
+
+DEFAULT_ADAPTERS = [
+    "default_planner_request_adapters/AddTimeParameterization",
+    "default_planner_request_adapters/FixWorkspaceBounds",
+    "default_planner_request_adapters/FixStartStateBounds",
+    "default_planner_request_adapters/FixStartStateCollision",
+    "default_planner_request_adapters/FixStartStatePathConstraints"
+]
+
+# Startup ROS
+print('Starting ROS...')
+ros = rf.ROS(len(argv), argv, "robowflex", 1)
+print('ROS running!')
+
+# Create the default Fetch robot
+print('Creating Fetch robot...')
+fetch = rf.FetchRobot()
+fetch.initialize(True)
+
+# Create an empty scene
+print('Creating scene...')
+scene = rf.Scene(fetch)
+
+# Create the default planner for the Fetch
+print('Creating planner...')
+planner = rf.FetchOMPLPipelinePlanner(fetch, "default")
+planner.initialize(rf.Settings(), DEFAULT_ADAPTERS)
+
+# Set the Fetch's base pose
+print('Posing Fetch...')
+fetch.set_base_pose(1, 1, 0.5)
+
+# Set the Fetch's head pose to look at a point
+fetch.point_head([2, 1, 1.5])
+
+# Create a motion planning request with a pose goal
+print('Creating planning request...')
+request = rf.MotionRequestBuilder(planner, GROUP, '')
+fetch.set_group_state(GROUP, [0.05, 1.32, 1.40, -0.2, 1.72, 0.0, 1.66, 0.0])
+request.set_start_configuration(fetch.get_scratch_state())
+
+# Unfurl
+fetch.set_group_state(GROUP, [0.265, 0.501, 1.281, -2.272, 2.243, -2.774, 0.976, -2.007])
+request.set_goal_configuration(fetch.get_scratch_state())
+request.set_config("RRTConnect")
+
+# Do motion planning!
+print('Motion planning...')
+result = planner.plan(scene, request.get_request())
+# NOTE: We don't export the MoveIt messages library; could probably get the below constant from the
+# Python bindings but I'm lazy
+if result.error_code_.val != 1:
+  raise RuntimeError(f'Motion planning failed with code: {result.error_code_.val}')
+
+# Create a trajectory object for better manipulation
+print('Exporting trajectory...')
+trajectory = rf.Trajectory(result.trajectory_)
+
+# Output path to a file for visualization
+trajectory.to_yaml_file("fetch_path.yml")

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -385,11 +385,13 @@ def generate_class(class_node: Cursor,
 
 
 def get_namespaces(top_level_node: Cursor) -> List[Cursor]:
+    namespaces = []
     if top_level_node.kind == CursorKind.NAMESPACE:    # type: ignore
-        return [top_level_node]
-    else:
-        return get_nodes_with_kind(top_level_node.get_children(),
-                                   [CursorKind.NAMESPACE])    # type: ignore
+        namespaces.append(top_level_node)
+    namespaces.extend(
+        get_nodes_with_kind(top_level_node.get_children(),
+                            [CursorKind.NAMESPACE]))    # type: ignore
+    return namespaces
 
 
 def get_pointer_defs(top_level_node: Cursor) -> Set[str]:

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -194,7 +194,7 @@ def generate_constructor_wrapper(qualified_name: str,
             else:
                 vec_elem_type = canonical_typ.get_pointee().spelling
 
-            modified_arg_types.append(f'std::vector<{vec_elem_type}>')
+            modified_arg_types.append(f'const std::vector<{vec_elem_type}>&')
             modified_arg_indices.add(i)
         else:
             modified_arg_types.append(canonical_typ.spelling)

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -90,8 +90,14 @@ def generate_overloads(name: str,
         is_static = function_node.is_static_method()
         function_pointer_signature = generate_function_pointer_signature(
             qualified_name, function_node, is_static, class_node)
+        if is_static:
+            # NOTE: This is a gross hack but seems necessary given limitations of pybind11
+            overload_name = f'{name}_static'
+        else:
+            overload_name = name
+
         overloads.append(
-            f'{".def_static" if is_static else ".def"}("{name}", static_cast<{function_pointer_signature}>(&{qualified_name}::{function_node.spelling}))'
+            f'{".def_static" if is_static else ".def"}("{overload_name}", static_cast<{function_pointer_signature}>(&{qualified_name}::{function_node.spelling}))'
         )
 
     return overloads

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -161,7 +161,7 @@ def generate_constructors(class_node: Cursor) -> List[str]:
             class_node.get_children(),
         [CursorKind.CONSTRUCTOR]):    # type: ignore
         constructors.append(
-            f".def(py::init<{', '.join([typ.spelling for typ in constructor_node.type.argument_types()])}>())"
+            f".def(py::init<{', '.join([typ.get_canonical().spelling for typ in constructor_node.type.argument_types()])}>())"
         )
 
     return constructors
@@ -309,6 +309,7 @@ def bind_classes(top_level_node: Cursor) -> List[str]:
     return output
 
 
+# TODO Templates
 def bind_functions(top_level_node: Cursor) -> List[str]:
     output = []
     for ns in get_namespaces(top_level_node):

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -227,9 +227,15 @@ def generate_constructors(class_node: Cursor, qualified_name: str) -> List[str]:
                     generate_constructor_wrapper(
                         qualified_name, constructor_node.type.argument_types()))
             else:
+                constructor_type_string = ''
+                constructor_argument_types = [
+                    typ.get_canonical().spelling
+                    for typ in constructor_node.type.argument_types()
+                ]
+                if constructor_argument_types:
+                    constructor_type_string = f'<{", ".join(constructor_argument_types)}>'
                 constructors.append(
-                    f".def(py::init<{', '.join([typ.get_canonical().spelling for typ in constructor_node.type.argument_types()])}>())"
-                )
+                    f".def(py::init{constructor_type_string}())")
 
     return constructors
 

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -8,7 +8,13 @@ from typing import Dict, Iterable, List, Set, Tuple
 
 import clang.cindex
 from clang.cindex import (AccessSpecifier, AvailabilityKind, Cursor, CursorKind,
-                          Index, TranslationUnit, Type, TypeKind)
+                          Index, SourceLocation, TranslationUnit, Type,
+                          TypeKind)
+
+
+def format_extent(extent) -> str:
+    start_loc: SourceLocation = extent.start
+    return f'{start_loc.file.name}: line {start_loc.line}'    # type: ignore
 
 
 def load_data(compilation_database_file: Path,

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -1,0 +1,315 @@
+import re
+from collections import defaultdict
+from pathlib import Path
+from sys import argv
+from typing import Dict, Iterable, List, Set, Tuple
+
+import clang.cindex
+from clang.cindex import (AccessSpecifier, Cursor, CursorKind, Index,
+                          TranslationUnit)
+
+
+def load_data(compilation_database_file: Path,
+              cpp_file: Path) -> Tuple[Index, TranslationUnit]:
+    # Parse the given input file
+    index = clang.cindex.Index.create()
+    comp_db = clang.cindex.CompilationDatabase.fromDirectory(
+        compilation_database_file)
+    commands = comp_db.getCompileCommands(cpp_file)
+    file_args = []
+    for command in commands:
+        for argument in command.arguments:
+            file_args.append(argument)
+    file_args = file_args[2:-1]
+    translation_unit = index.parse(cpp_file, file_args)
+    return index, translation_unit
+
+
+def get_nodes_from_file(nodes: Iterable[Cursor],
+                        file_name: str) -> List[Cursor]:
+    return list(filter(lambda n: n.location.file.name == file_name, nodes))
+
+
+def get_nodes_with_kind(nodes: Iterable[Cursor],
+                        node_kinds: Iterable[CursorKind]) -> List[Cursor]:
+    return list(filter(lambda n: n.kind in node_kinds, nodes))
+
+
+# This approach to snake-case conversion adapted from:
+# https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
+SPECIAL_KEYWORDS = re.compile(r'ID|YAML|SRDF|URDF|JSON|IK')
+NAIVE_CAMEL_CASE = re.compile(r'(.)([A-Z][a-z]+)')
+CAMEL_CASE_UNDERSCORES = re.compile(r'__([A-Z])')
+ADVANCED_CAMEL_CASE = re.compile(r'([a-z0-9])([A-Z])')
+
+
+def downcase_keywords(kwd_match: re.Match) -> str:
+    kwd = kwd_match.group(0)
+    return kwd[0] + kwd[1:].lower()
+
+
+def to_snake_case(camel_name: str) -> str:
+    snake_name = SPECIAL_KEYWORDS.sub(downcase_keywords, camel_name)
+    snake_name = NAIVE_CAMEL_CASE.sub(r'\1_\2', snake_name)
+    snake_name = CAMEL_CASE_UNDERSCORES.sub(r'_\1', snake_name)
+    snake_name = ADVANCED_CAMEL_CASE.sub(r'\1_\2', snake_name)
+    return snake_name.lower()
+
+
+def generate_function_pointer_signature(ns_name: str,
+                                        function_node: Cursor,
+                                        class_node: Cursor = None) -> str:
+    signature = f'{function_node.type.get_result().spelling} ({ns_name + "::" + class_node.spelling + "::*" if class_node else "*"})('
+    for typ in function_node.type.argument_types():
+        signature += f'{typ.spelling}, '
+
+    signature = signature[:-2] + ')'
+    return signature
+
+
+def generate_overloads(name: str,
+                       nodes: Iterable[Cursor],
+                       ns_name: str,
+                       class_node: Cursor = None) -> List[str]:
+    overloads = []
+    for function_node in nodes:
+        function_pointer_signature = generate_function_pointer_signature(
+            ns_name, function_node, class_node)
+        overloads.append(
+            f'.def("{name}, static_cast<{function_pointer_signature}>(&{ns_name}::{class_node.spelling + "::" if class_node else ""}{function_node.spelling}))'
+        )
+
+    return overloads
+
+
+def is_exposed(node: Cursor) -> bool:
+    return node.access_specifier == AccessSpecifier.PUBLIC    # type: ignore
+
+
+# TODO: This could be more efficient if we called get_children once per class and iterated over it
+# multiple times, at the cost of threading that list through in the parameters
+# TODO: Could also improve efficiency with stronger preference for iterators over explicit lists
+
+
+def get_exposed_fields(class_node: Cursor) -> List[Cursor]:
+    fields = get_nodes_with_kind(class_node.get_children(),
+                                 [CursorKind.FIELD_DECL])    # type: ignore
+    return list(filter(is_exposed, fields))
+
+
+def get_exposed_static_variables(class_node: Cursor) -> List[Cursor]:
+    fields = get_nodes_with_kind(class_node.get_children(),
+                                 [CursorKind.VAR_DECL])    # type: ignore
+    return list(filter(is_exposed, fields))
+
+
+def get_exposed_methods(class_node: Cursor) -> List[Cursor]:
+    methods = get_nodes_with_kind(class_node.get_children(),
+                                  [CursorKind.CXX_METHOD])    # type: ignore
+    return list(filter(is_exposed, methods))
+
+
+# TODO: Handle default arguments
+# TODO: Maybe generate keyword args?
+
+
+def generate_constructors(class_node: Cursor) -> List[str]:
+    constructors = []
+    for constructor_node in get_nodes_with_kind(
+            class_node.get_children(),
+        [CursorKind.CONSTRUCTOR]):    # type: ignore
+        constructors.append(
+            f".def(py::init<{', '.join([typ.spelling for typ in constructor_node.type.argument_types()])}>())"
+        )
+
+    return constructors
+
+
+def generate_methods(class_node: Cursor, ns_name: str) -> List[str]:
+    class_method_nodes = defaultdict(list)
+    for method_node in get_exposed_methods(class_node):
+        class_method_nodes[to_snake_case(
+            method_node.spelling)].append(method_node)
+
+    methods = []
+    for method_name, method_nodes in class_method_nodes.items():
+        if len(method_nodes) > 1:
+            methods.extend(
+                generate_overloads(method_name, method_nodes, ns_name,
+                                   class_node))
+        else:
+            methods.append(
+                f'.def("{method_name}", &{ns_name}::{class_node.spelling}::{method_nodes[0].spelling})'
+            )
+
+    return methods
+
+
+def generate_fields(class_node: Cursor, ns_name: str) -> List[str]:
+    fields = []
+    # Instance fields
+    for field_node in get_exposed_fields(class_node):
+        field_binder = '.def_readwrite'
+        if field_node.type.is_const_qualified():
+            field_binder = '.def_readonly'
+
+        fields.append(
+            f'{field_binder}("{to_snake_case(field_node.spelling)}", &{ns_name}::{class_node.spelling}::{field_node.spelling})'
+        )
+
+    # Static variables
+    for static_var_node in get_exposed_static_variables(class_node):
+        var_binder = '.def_readwrite'
+        if static_var_node.type.is_const_qualified():
+            var_binder = '.def_readonly_static'
+
+        fields.append(
+            f'{var_binder}("{to_snake_case(static_var_node.spelling)}", &{ns_name}::{class_node.spelling}::{static_var_node.spelling})'
+        )
+
+    return fields
+
+
+def get_nested_types(class_node: Cursor) -> List[Cursor]:
+    return get_nodes_with_kind(
+        class_node.get_children(),
+        [CursorKind.CLASS_DECL, CursorKind.STRUCT_DECL])    # type: ignore
+
+
+def generate_class(class_node: Cursor,
+                   ns_name: str,
+                   pointer_names: Set[str],
+                   parent_class: str = None) -> List[str]:
+    # Handle forward declarations
+    class_definition_node = class_node.get_definition()
+    if class_definition_node is None or class_definition_node != class_node:
+        return []
+
+    parent_object = f'py_{parent_class}' if parent_class else 'm'
+
+    superclasses = []
+    for superclass_node in get_nodes_with_kind(
+            class_node.get_children(),
+        [CursorKind.CXX_BASE_SPECIFIER]):    # type: ignore
+        superclasses.append(superclass_node.type.spelling)
+
+    superclass_string = ''
+    if superclasses:
+        superclass_string = f', {",".join(superclasses)}'
+
+    pointer_string = ''
+    pointer_type_name = f'{class_node.spelling}Ptr'
+    if pointer_type_name in pointer_names:
+        pointer_string = f', {ns_name}::{pointer_type_name}'
+
+    class_output = [
+        f'// Bindings for class {ns_name}',
+        f'py::class_<{ns_name}::{class_node.spelling}{superclass_string}{pointer_string}>({parent_object}, "{class_node.spelling}")'
+    ]
+    # Constructors
+    class_output.extend(generate_constructors(class_node))
+
+    # Methods
+    class_output.extend(generate_methods(class_node, ns_name))
+
+    # Fields
+    class_output.extend(generate_fields(class_node, ns_name))
+
+    # Nested types
+    nested_output = []
+    for nested_type_node in get_nested_types(class_node):
+        nested_output.extend(
+            generate_class(nested_type_node, ns_name, class_node.spelling))
+
+    if nested_output:
+        class_output[
+            1] = f'py::class_<{ns_name}::{class_node.spelling}> py_{class_node.spelling}(m, "{class_node.spelling}")'
+
+    class_output.append(';')
+    return class_output
+
+
+def get_namespaces(top_level_node: Cursor) -> List[Cursor]:
+    if top_level_node.kind == CursorKind.NAMESPACE:    # type: ignore
+        return [top_level_node]
+    else:
+        return get_nodes_with_kind(top_level_node.get_children(),
+                                   [CursorKind.NAMESPACE])    # type: ignore
+
+
+def get_pointer_defs(top_level_node: Cursor) -> Set[str]:
+    typedef_nodes = get_nodes_with_kind(
+        top_level_node.get_children(),
+        [CursorKind.TYPEDEF_DECL])    # type: ignore
+    return {
+        node.spelling
+        for node in typedef_nodes if node.spelling[-3:].lower() == 'ptr'
+    }
+
+
+def bind_classes(top_level_node: Cursor) -> List[str]:
+    output = []
+    for ns in get_namespaces(top_level_node):
+        pointer_names = get_pointer_defs(ns)
+        for class_node in get_nodes_with_kind(
+                ns.get_children(),
+            [CursorKind.CLASS_DECL, CursorKind.STRUCT_DECL]):    # type: ignore
+            output.extend(generate_class(class_node, ns.spelling,
+                                         pointer_names))
+    return output
+
+
+def bind_functions(top_level_node: Cursor) -> List[str]:
+    output = []
+    for ns in get_namespaces(top_level_node):
+        ns_functions: Dict[str, List[Cursor]] = defaultdict(list)
+        # We do this in two stages to handle overloads
+        for function_node in get_nodes_with_kind(
+                ns.get_children(),
+            [CursorKind.FUNCTION_DECL]):    # type: ignore
+            ns_functions[to_snake_case(
+                function_node.spelling)].append(function_node)
+
+        for function_name, function_nodes in ns_functions.items():
+            if len(function_nodes) > 1:
+                output.append('m')
+                output.extend(
+                    generate_overloads(function_name, function_nodes,
+                                       ns.spelling))
+                output.append(';')
+            else:
+                output.append(
+                    f'm.def("{function_name}", &{ns.spelling}::{function_nodes[0].spelling});'
+                )
+    return output
+
+
+def print_tree(root: Cursor, depth: int = 0):
+    print(f'{"".join(["  "] * depth)}{root.displayname}: {root.kind}')
+    for child in root.get_children():
+        print_tree(child, depth + 1)
+
+
+if __name__ == '__main__':
+    compdb_path = Path(argv[1])
+    header_path = Path(argv[2])
+    module_name = argv[3]
+    index, translation_unit = load_data(compdb_path, header_path)
+    include_path = header_path.relative_to('include')
+
+    file_nodes = get_nodes_from_file(translation_unit.cursor.get_children(),
+                                     translation_unit.spelling)
+    for node in file_nodes:
+        print_tree(node)
+
+    output = [
+        r'#include <pybind11/pybind11.h', r'#include <pybind11/operators.h>',
+        f'#include <{include_path}>', 'namespace py = pybind11',
+        f'PYBIND11_MODULE({module_name}, m) {{'
+    ]
+    for node in file_nodes:
+        output.extend(bind_classes(node))
+        output.extend(bind_functions(node))
+
+    output.append('}')
+    print(output)

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -312,12 +312,9 @@ def generate_class(class_node: Cursor,
         superclasses.append(superclass_node.type.spelling)
 
     superclass_string = ''
-    pointer_string = ''
-    pointer_type_name = f'{class_node.spelling}Ptr'
-    if pointer_type_name in pointer_names:
-        pointer_string = f', {ns_name}::{pointer_type_name}'
-
     qualified_name = f'{ns_name}::{parent_class + "::" if parent_class else ""}{class_node.spelling}'
+    # NOTE: We assume that everything uses shared_ptr as its holder type for simplicity
+    pointer_string = f', std::shared_ptr<{qualified_name}>'
     class_output = [f'// Bindings for class {qualified_name}']
     filtered_superclasses = [
         superclass for superclass in superclasses if superclass[:5] != 'std::'

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -135,6 +135,10 @@ def is_exposed(node: Cursor) -> bool:
     return node.access_specifier == AccessSpecifier.PUBLIC    # type: ignore
 
 
+def is_not_private(node: Cursor) -> bool:
+    return node.access_specifier != AccessSpecifier.PRIVATE    # type: ignore
+
+
 # TODO: This could be more efficient if we called get_children once per class and iterated over it
 # multiple times, at the cost of threading that list through in the parameters
 # TODO: Could also improve efficiency with stronger preference for iterators over explicit lists
@@ -218,7 +222,9 @@ def generate_constructors(class_node: Cursor, qualified_name: str) -> List[str]:
     for constructor_node in get_nodes_with_kind(
             class_node.get_children(),
         [CursorKind.CONSTRUCTOR]):    # type: ignore
-        if constructor_node.availability != AvailabilityKind.NOT_AVAILABLE:    # type: ignore
+        if is_not_private(
+                constructor_node
+        ) and constructor_node.availability != AvailabilityKind.NOT_AVAILABLE:    # type: ignore
             # TODO: This could be cleaner
             if any(typ.get_pointee().get_pointee().kind !=
                    TypeKind.INVALID    # type: ignore

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -21,7 +21,10 @@ def load_data(compilation_database_file: Path,
     for command in commands:
         for argument in command.arguments:
             file_args.append(argument)
+
     file_args = file_args[2:-1]
+    # NOTE: Not sure why this needs to be manually included, but we don't find stddef otherwise
+    file_args.append('-I/usr/lib/clang/13.0.1/include')
     translation_unit = index.parse(cpp_file, file_args)
     return index, translation_unit
 

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -516,8 +516,7 @@ def toposort_bindings(bindings: List[Binding]) -> List[str]:
     for binding in filter(lambda b: not b.is_class, bindings):
         output.extend(binding.body)
 
-    for foo in output:
-        assert not isinstance(foo, Binding), str(foo)
+    assert not class_bindings, f'Could not resolve all type dependencies! {class_bindings}'
     return output
 
 

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -237,7 +237,8 @@ def generate_class(class_node: Cursor,
 
     if nested_output:
         class_output[
-            1] = f'py::class_<{ns_name}::{class_node.spelling}> py_{class_node.spelling}(m, "{class_node.spelling}")'
+            1] = f'py::class_<{ns_name}::{class_node.spelling}> py_{class_node.spelling}(m, "{class_node.spelling}");'
+        class_output[2] = f'py_{class_node.spelling}{class_output[2]}'
 
     class_output.append(';')
     return class_output

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Set, Tuple
 
 import clang.cindex
-from clang.cindex import (AccessSpecifier, Cursor, CursorKind, Index,
-                          TranslationUnit, Type)
+from clang.cindex import (AccessSpecifier, AvailabilityKind, Cursor, CursorKind,
+                          Index, TranslationUnit, Type)
 
 
 def load_data(compilation_database_file: Path,
@@ -160,9 +160,10 @@ def generate_constructors(class_node: Cursor) -> List[str]:
     for constructor_node in get_nodes_with_kind(
             class_node.get_children(),
         [CursorKind.CONSTRUCTOR]):    # type: ignore
-        constructors.append(
-            f".def(py::init<{', '.join([typ.get_canonical().spelling for typ in constructor_node.type.argument_types()])}>())"
-        )
+        if constructor_node.availability != AvailabilityKind.NOT_AVAILABLE:    # type: ignore
+            constructors.append(
+                f".def(py::init<{', '.join([typ.get_canonical().spelling for typ in constructor_node.type.argument_types()])}>())"
+            )
 
     return constructors
 

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -210,7 +210,7 @@ def generate_constructor_wrapper(qualified_name: str,
         modified_arg_indices else f'convertVec({arg_name}).data()'
         for i, arg_name in enumerate(arg_names))
 
-    return f'.def(py::init([]({", ".join(lambda_args)}) {{return {qualified_name}({invocation_expr});}}))'
+    return f'.def(py::init([]({", ".join(lambda_args)}) {{return std::make_shared<{qualified_name}>({invocation_expr});}}))'
 
 
 def generate_constructors(class_node: Cursor, qualified_name: str) -> List[str]:

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -178,7 +178,9 @@ def generate_methods(class_node: Cursor, qualified_name: str) -> List[str]:
         # Handle operators
         if method_name[:8] == 'operator':
             operator = method_name[8:].strip()
-            if operator[:3] == 'new' or operator[:6] == 'delete':
+            if operator[:
+                        3] == 'new' or operator[:
+                                                6] == 'delete' or operator == '=':
                 continue
 
             methods.extend(generate_operator_methods(operator, method_nodes))

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -360,7 +360,8 @@ def generate_class(class_node: Cursor,
         class_output.extend(generate_fields(class_node, qualified_name))
 
         # Nested types
-        for nested_type_node in get_nested_types(class_node):
+        for nested_type_node in filter(is_not_private,
+                                       get_nested_types(class_node)):
             nested_output.extend(
                 generate_class(nested_type_node, ns_name, pointer_names,
                                qualified_name))

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -260,7 +260,8 @@ def generate_class(class_node: Cursor,
         f'py::class_<{qualified_name}{superclass_string}{pointer_string}>({parent_object}, "{class_node.spelling}")'
     ]
     # Constructors
-    class_output.extend(generate_constructors(class_node))
+    if not class_node.is_abstract_record():
+      class_output.extend(generate_constructors(class_node))
 
     # Methods
     class_output.extend(generate_methods(class_node, qualified_name))

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -217,7 +217,7 @@ def generate_class(class_node: Cursor,
         pointer_string = f', {ns_name}::{pointer_type_name}'
 
     class_output = [
-        f'// Bindings for class {ns_name}',
+        f'// Bindings for class {ns_name}::{class_node.spelling}',
         f'py::class_<{ns_name}::{class_node.spelling}{superclass_string}{pointer_string}>({parent_object}, "{class_node.spelling}")'
     ]
     # Constructors

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -321,9 +321,6 @@ if __name__ == '__main__':
 
     file_nodes = get_nodes_from_file(translation_unit.cursor.get_children(),
                                      translation_unit.spelling)
-    for node in file_nodes:
-        print_tree(node)
-
     output = [
         r'#include <pybind11/pybind11.h', r'#include <pybind11/operators.h>',
         f'#include <{include_path}>', 'namespace py = pybind11',

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -77,7 +77,7 @@ def generate_overloads(name: str,
         function_pointer_signature = generate_function_pointer_signature(
             ns_name, function_node, class_node)
         overloads.append(
-            f'.def("{name}, static_cast<{function_pointer_signature}>(&{ns_name}::{class_node.spelling + "::" if class_node else ""}{function_node.spelling}))'
+            f'.def("{name}", static_cast<{function_pointer_signature}>(&{ns_name}::{class_node.spelling + "::" if class_node else ""}{function_node.spelling}))'
         )
 
     return overloads
@@ -322,9 +322,9 @@ if __name__ == '__main__':
     file_nodes = get_nodes_from_file(translation_unit.cursor.get_children(),
                                      translation_unit.spelling)
     output = [
-        r'#include <pybind11/pybind11.h', r'#include <pybind11/operators.h>',
-        f'#include <{include_path}>', 'namespace py = pybind11',
-        f'PYBIND11_MODULE({module_name}, m) {{'
+        r'#include <pybind11/pybind11.h>', r'#include <pybind11/operators.h>',
+        f'#include <{include_path}>', 'namespace py = pybind11;',
+        f'PYBIND11_MODULE({args.module_name}, m) {{'
     ]
     for node in file_nodes:
         output.extend(bind_classes(node))

--- a/robowflex_library/generate_bindings.py
+++ b/robowflex_library/generate_bindings.py
@@ -542,8 +542,13 @@ if __name__ == '__main__':
                             type = Path)
     args = arg_parser.parse_args()
     prefix = [
-        r'#include <pybind11/pybind11.h>', r'#include <pybind11/operators.h>',
-        r'''
+        r'''#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <pybind11/eigen.h>
+#include <pybind11/stl_bind.h>
+#include <pybind11/cast.h>
+#include <pybind11/functional.h>''', r'''
 template <typename ElemT, typename ResultT=ElemT>
 std::vector<ResultT> convertVec(const std::vector<ElemT>& vec) {
   return vec;

--- a/robowflex_library/include/robowflex_library/planning.h
+++ b/robowflex_library/include/robowflex_library/planning.h
@@ -361,9 +361,9 @@ namespace robowflex
 
             std::vector<std::string> getPlannerConfigs() const override;
 
+            static const std::vector<std::string> DEFAULT_ADAPTERS;  ///< The default planning adapters.
         protected:
             static const std::string DEFAULT_PLUGIN;                 ///< The default OMPL plugin.
-            static const std::vector<std::string> DEFAULT_ADAPTERS;  ///< The default planning adapters.
 
         private:
             std::vector<std::string> configs_;  ///< Planning configurations loaded from \a config_file in

--- a/robowflex_library/include/robowflex_library/tf.h
+++ b/robowflex_library/include/robowflex_library/tf.h
@@ -169,8 +169,6 @@ namespace robowflex
                                                               const RobotPose &pose,
                                                               const GeometryConstPtr &geometry);
 
-        Eigen::Vector3d samplePositionConstraint(const moveit_msgs::PositionConstraint &pc);
-
         /** \brief Get an orientation constraint message.
          *  \param[in] ee_name The name of the end-effector link.
          *  \param[in] base_name The frame of pose and orientation.

--- a/robowflex_library/package.xml
+++ b/robowflex_library/package.xml
@@ -19,6 +19,7 @@
   <depend>tinyxml2</depend>
   <depend>eigen</depend>
   <depend>hdf5</depend>
+  <depend>pybind11</depend>
 
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/robowflex_library/src/python_bindings.cpp
+++ b/robowflex_library/src/python_bindings.cpp
@@ -1,0 +1,135 @@
+#include <pybind11/pybind11.h>
+
+#include <robowflex_library/builder.h>
+#include <robowflex_library/detail/fetch.h>
+#include <robowflex_library/planning.h>
+#include <robowflex_library/robot.h>
+#include <robowflex_library/scene.h>
+#include <robowflex_library/trajectory.h>
+#include <robowflex_library/util.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace py = pybind11;
+namespace rf = robowflex;
+
+PYBIND11_MODULE(robowflex_library, m)
+{
+    m.doc() = "Robowflex: MoveIt made easy";
+
+    // Bindings from util.h
+    py::class_<rf::Exception>(m, "RobowflexException")
+        .def(py::init<int, const std::string &>())
+        .def_property_readonly("value", &rf::Exception::getValue)
+        .def_property_readonly("message", &rf::Exception::getMessage)
+        .def("what", &rf::Exception::what);
+
+    py::class_<rf::ROS>(m, "ROS")
+        .def(py::init([](int argc, std::vector<char *> &argv, const std::string &name, unsigned int threads)
+                      { return rf::ROS(argc, argv.data(), name, threads); }),
+             py::arg("argc"), py::arg("argv"), py::arg("name") = "robowflex", py::arg("threads") = 1)
+        .def("get_args", &rf::ROS::getArgs)
+        .def("wait", &rf::ROS::wait);
+
+    m.def("explode", &rf::explode);
+    // End bindings from util.h
+
+    // Bindings from detail/fetch.h
+    py::class_<rf::FetchRobot, rf::FetchRobotPtr>(m, "FetchRobot")
+        .def(py::init())
+        .def("initialize", &rf::FetchRobot::initialize)
+        .def("add_casters_URDF", &rf::FetchRobot::addCastersURDF)
+        .def("set_base_pose", &rf::FetchRobot::setBasePose)
+        .def("point_head", &rf::FetchRobot::pointHead)
+        .def("open_gripper", &rf::FetchRobot::openGripper)
+        .def("close_gripper", &rf::FetchRobot::closeGripper);
+
+    using FOPipelinePlanner = rf::OMPL::FetchOMPLPipelinePlanner;
+    py::class_<FOPipelinePlanner, std::shared_ptr<FOPipelinePlanner>>(m, "FetchOMPLPipelinePlanner")
+        .def(py::init<const rf::RobotPtr &, const std::string &>())
+        .def("initialize", &rf::OMPL::FetchOMPLPipelinePlanner::initialize,
+             py::arg("settings") = rf::OMPL::Settings(),
+             py::arg("adapters") = rf::OMPL::OMPLPipelinePlanner::DEFAULT_ADAPTERS);
+    // End bindings from detail/fetch.h
+
+    // Bindings from builder.h
+    py::class_<rf::MotionRequestBuilder, rf::MotionRequestBuilderPtr>(m, "MotionRequestBuilder")
+        .def(py::init<const rf::RobotConstPtr &>())
+        .def(py::init<const rf::RobotConstPtr &, const std::string &, const std::string &>())
+        .def(py::init<const rf::PlannerConstPtr &, const std::string &, const std::string &>())
+        .def(py::init<const rf::MotionRequestBuilder &>())
+        .def("clone", &rf::MotionRequestBuilder::clone)
+        .def("initialize", &rf::MotionRequestBuilder::initialize)
+        .def("set_planning_group", &rf::MotionRequestBuilder::setPlanningGroup)
+        .def("set_planner", &rf::MotionRequestBuilder::setPlanner)
+        .def("set_start_configuration",
+             static_cast<void (rf::MotionRequestBuilder::*)(const std::vector<double> &)>(
+                 &rf::MotionRequestBuilder::setStartConfiguration))
+        .def("set_start_configuration",
+             static_cast<void (rf::MotionRequestBuilder::*)(const robot_state::RobotState &)>(
+                 &rf::MotionRequestBuilder::setStartConfiguration))
+        .def("set_start_configuration",
+             static_cast<void (rf::MotionRequestBuilder::*)(const robot_state::RobotStatePtr &)>(
+                 &rf::MotionRequestBuilder::setStartConfiguration))
+        .def("use_scene_state_as_start", &rf::MotionRequestBuilder::useSceneStateAsStart)
+        .def("attach_object_to_start", &rf::MotionRequestBuilder::attachObjectToStart)
+        .def("attach_object_to_start_const", &rf::MotionRequestBuilder::attachObjectToStartConst)
+        .def("add_goal_configuration",
+             static_cast<void (rf::MotionRequestBuilder::*)(const std::vector<double> &)>(
+                 &rf::MotionRequestBuilder::addGoalConfiguration))
+        .def("add_goal_configuration",
+             static_cast<void (rf::MotionRequestBuilder::*)(const robot_state::RobotStatePtr &)>(
+                 &rf::MotionRequestBuilder::addGoalConfiguration))
+        .def("add_goal_configuration",
+             static_cast<void (rf::MotionRequestBuilder::*)(const robot_state::RobotState &)>(
+                 &rf::MotionRequestBuilder::addGoalConfiguration))
+        .def("add_goal_from_IK_query", &rf::MotionRequestBuilder::addGoalFromIKQuery)
+        .def("add_goal_pose", &rf::MotionRequestBuilder::addGoalPose)
+        .def("add_goal_region", &rf::MotionRequestBuilder::addGoalRegion)
+        .def("add_goal_rotary_tile", &rf::MotionRequestBuilder::addGoalRotaryTile)
+        .def("add_cylinder_side_grasp", &rf::MotionRequestBuilder::addCylinderSideGrasp)
+        .def("set_goal_configuration",
+             static_cast<void (rf::MotionRequestBuilder::*)(const std::vector<double> &)>(
+                 &rf::MotionRequestBuilder::setGoalConfiguration))
+        .def("set_goal_configuration",
+             static_cast<void (rf::MotionRequestBuilder::*)(const robot_state::RobotStatePtr &)>(
+                 &rf::MotionRequestBuilder::setGoalConfiguration))
+        .def("set_goal_configuration",
+             static_cast<void (rf::MotionRequestBuilder::*)(const robot_state::RobotState &)>(
+                 &rf::MotionRequestBuilder::setGoalConfiguration))
+        .def("set_goal_from_IK_query", &rf::MotionRequestBuilder::setGoalFromIKQuery)
+        .def("set_goal_pose", &rf::MotionRequestBuilder::setGoalPose)
+        .def("set_goal_region", &rf::MotionRequestBuilder::setGoalRegion)
+        .def("precompute_goal_configurations", &rf::MotionRequestBuilder::precomputeGoalConfigurations)
+        .def("clear_goals", &rf::MotionRequestBuilder::clearGoals)
+        .def("add_path_pose_constraint", &rf::MotionRequestBuilder::addPathPoseConstraint)
+        .def("add_path_position_constraint", &rf::MotionRequestBuilder::addPathPositionConstraint)
+        .def("add_path_orientation_constraint", &rf::MotionRequestBuilder::addPathOrientationConstraint)
+        .def("set_config", &rf::MotionRequestBuilder::setConfig)
+        .def("set_allowed_planning_time", &rf::MotionRequestBuilder::setAllowedPlanningTime)
+        .def("set_num_planning_attempts", &rf::MotionRequestBuilder::setNumPlanningAttempts)
+        .def("set_workspace_bounds",
+             static_cast<void (rf::MotionRequestBuilder::*)(const moveit_msgs::WorkspaceParameters &)>(
+                 &rf::MotionRequestBuilder::setWorkspaceBounds))
+        .def("set_workspace_bounds",
+             static_cast<void (rf::MotionRequestBuilder::*)(const Eigen::Ref<const Eigen::VectorXd> &,
+                                                            const Eigen::Ref<const Eigen::VectorXd> &)>(
+                 &rf::MotionRequestBuilder::setWorkspaceBounds))
+        .def("swap_start_with_goal", &rf::MotionRequestBuilder::swapStartWithGoal)
+        .def("get_request", &rf::MotionRequestBuilder::getRequest)
+        .def("get_request_const", &rf::MotionRequestBuilder::getRequestConst)
+        .def("get_start_configuration", &rf::MotionRequestBuilder::getStartConfiguration)
+        .def("get_goal_configuration", &rf::MotionRequestBuilder::getGoalConfiguration)
+        .def("get_path_constraints", &rf::MotionRequestBuilder::getPathConstraints)
+        .def("get_robot", &rf::MotionRequestBuilder::getRobot)
+        .def("get_planner", &rf::MotionRequestBuilder::getPlanner)
+        .def("get_planning_group", &rf::MotionRequestBuilder::getPlanningGroup)
+        .def("get_planner_config", &rf::MotionRequestBuilder::getPlannerConfig)
+        .def("to_yaml_file", &rf::MotionRequestBuilder::toYAMLFile)
+        .def("from_yaml_file", &rf::MotionRequestBuilder::fromYAMLFile);
+    // End bindings from builder.h
+
+    // TODO: Scene, Robot, MotionPlanResponse, Trajectory
+}


### PR DESCRIPTION
This PR adds a generator for Python bindings, using `pybind11` and `libclang`. It is intended as a MVP for Python bindings; additional features (e.g. bidirectional bindings to allow overriding of virtual methods from Python) would be good to add in the future.

This isn't 100% ready for merge yet, but it's done enough that I wanted to make a draft PR to start getting eyes on the work. Currently, the `generate_bindings.py` script can successfully generate `pybind11` code for the entirety of `robowflex_library`, with the following caveats/TODOs which should be resolved prior to merge.

- [ ] It doesn't currently recognize and filter out template methods (these are only supported in specific instantiations)
- [ ] No support for keyword/default arguments
- [ ] `generate_bindings` could use some cleanup and commenting/documentation
- [ ] We don't yet have a solution for generating bindings for external types that `robowflex` needs, e.g. `moveit_msgs::RobotState` (which currently blocks `fetch_test.py` from executing correctly)
- [ ] Integration with the build isn't quite right: the extension library isn't installed to Python's search path
- [ ] [optional] Should allow multiple modules/a hierarchical structure
- [ ] [optional] Should allow combination with manual bindings for special cases