### PR TITLE
Stretch robot and mobile manipulation planning

### DIFF
--- a/robowflex_library/CMakeLists.txt
+++ b/robowflex_library/CMakeLists.txt
@@ -142,7 +142,7 @@ add_script(cob4_test)
 add_script(cob4_visualization)
 add_script(cob4_multi_target)
 add_script(stretch_test)
-add_script(stretch_visualization)
+add_script(stretch_mobile_manipulation)
 ##
 ## Tests
 ##

--- a/robowflex_library/CMakeLists.txt
+++ b/robowflex_library/CMakeLists.txt
@@ -86,6 +86,7 @@ list(APPEND SOURCES
   src/detail/ur5.cpp
   src/detail/fetch.cpp
   src/detail/cob4.cpp
+  src/detail/stretch.cpp
   )
 
 list(APPEND INCLUDES
@@ -140,7 +141,8 @@ add_script(shadowhand_ik)
 add_script(cob4_test)
 add_script(cob4_visualization)
 add_script(cob4_multi_target)
-
+add_script(stretch_test)
+add_script(stretch_visualization)
 ##
 ## Tests
 ##

--- a/robowflex_library/include/robowflex_library/detail/stretch.h
+++ b/robowflex_library/include/robowflex_library/detail/stretch.h
@@ -1,0 +1,102 @@
+/* Author: Carlos Quintero-Peña */
+
+#ifndef ROBOWFLEX_STRETCH_
+#define ROBOWFLEX_STRETCH_
+
+#include <robowflex_library/planning.h>
+#include <robowflex_library/robot.h>
+
+namespace robowflex
+{
+    /** \cond IGNORE */
+    ROBOWFLEX_CLASS_FORWARD(StretchRobot);
+    /* \endcond */
+
+    /** \class robowflex::StretchRobotPtr
+        \brief A shared pointer wrapper for robowflex::StretchRobot. */
+
+    /** \class robowflex::StretchRobotConstPtr
+        \brief A const shared pointer wrapper for robowflex::StretchRobot. */
+
+    /** \brief Convenience class that describes the default setup for Stretch.
+     *  Will first attempt to load configuration and description from the robowflex_resources package.
+     *  See https://github.com/KavrakiLab/robowflex_resources for this package.
+     *  If this package is not available, then stretch_description / stretch_moveit_config packages will be
+     * used.
+     */
+    class StretchRobot : public Robot
+    {
+    public:
+        /** \brief Constructor.
+         */
+        StretchRobot();
+
+        /** \brief Initialize the robot with stretch_arm, stretch_gripper and stretch_head kinematics.
+         *  \return True on success, false on failure.
+         */
+        bool initialize();
+
+        /** \brief Points the Stretch's head to a point in the world frame.
+         *  \param[in] point The point to look at.
+         */
+        void pointHead(const Eigen::Vector3d &point);
+
+        /** \brief Opens the Stretch's gripper.
+         */
+        void openGripper();
+
+        /** \brief Closes the Stretch's gripper.
+         */
+        void closeGripper();
+
+    private:
+        static const std::string DEFAULT_URDF;        ///< Default URDF
+        static const std::string DEFAULT_SRDF;        ///< Default SRDF
+        static const std::string DEFAULT_LIMITS;      ///< Default Limits
+        static const std::string DEFAULT_KINEMATICS;  ///< Default kinematics
+
+        static const std::string RESOURCE_URDF;        ///< URDF from robowflex_resources
+        static const std::string RESOURCE_SRDF;        ///< SRDF from robowflex_resources
+        static const std::string RESOURCE_LIMITS;      ///< Limits from robowflex_resources
+        static const std::string RESOURCE_KINEMATICS;  ///< kinematics from robowflex_resources
+    };
+
+    namespace OMPL
+    {
+        /** \cond IGNORE */
+        ROBOWFLEX_CLASS_FORWARD(StretchOMPLPipelinePlanner);
+        /* \endcond */
+
+        /** \class robowflex::OMPL::StretchOMPLPipelinePlannerPtr
+            \brief A shared pointer wrapper for robowflex::OMPL::StretchOMPLPipelinePlanner. */
+
+        /** \class robowflex::OMPL::StretchOMPLPipelinePlannerConstPtr
+            \brief A const shared pointer wrapper for robowflex::OMPL::StretchOMPLPipelinePlanner. */
+
+        /** \brief Convenience class for the default motion planning pipeline for Stretch.
+         */
+        class StretchOMPLPipelinePlanner : public OMPLPipelinePlanner
+        {
+        public:
+            /** \brief Constructor.
+             *  \param[in] robot Robot to create planner for.
+             *  \param[in] name Namespace of this planner.
+             */
+            StretchOMPLPipelinePlanner(const RobotPtr &robot, const std::string &name = "");
+
+            /** \brief Initialize the planning context. All parameter provided are defaults.
+             *  \param[in] settings Settings to set on the parameter server.
+             *  \param[in] adapters Planning adapters to load.
+             *  \return True on success, false on failure.
+             */
+            bool initialize(const Settings &settings = Settings(),
+                            const std::vector<std::string> &adapters = DEFAULT_ADAPTERS);
+
+        private:
+            static const std::string DEFAULT_CONFIG;   ///< Default planning configuration.
+            static const std::string RESOURCE_CONFIG;  ///< Planning configuration from robowflex_resources.
+        };
+    }  // namespace OMPL
+}  // namespace robowflex
+
+#endif

--- a/robowflex_library/include/robowflex_library/detail/stretch.h
+++ b/robowflex_library/include/robowflex_library/detail/stretch.h
@@ -31,10 +31,22 @@ namespace robowflex
          */
         StretchRobot();
 
-        /** \brief Initialize the robot with stretch_arm, stretch_gripper and stretch_head kinematics.
+        /** \brief Initialize the robot.
+         *  \param[in] addVirtual Whether a virtual joint for the base should be added to the srdf descrition
+         * or not.
+         *  \param[in] addBaseManip Whether a base + manipulator group should be added to the srdf
+         * representation or not. If set, two groups will be added, one for the base and one for the mobile
+         * base manipulator.
          *  \return True on success, false on failure.
          */
-        bool initialize(bool addVirtual = true);
+        bool initialize(bool addVirtual = true, bool addBaseManip = false);
+
+        /** \brief Sets the base pose of the Stretch robot (a virtual planar joint)
+         *  \param[in] x The x position.
+         *  \param[in] y The y position.
+         *  \param[in] theta The angle.
+         */
+        void setBasePose(double x, double y, double theta);
 
         /** \brief Points the Stretch's head to a point in the world frame.
          *  \param[in] point The point to look at.
@@ -48,8 +60,6 @@ namespace robowflex
         /** \brief Closes the Stretch's gripper.
          */
         void closeGripper();
-        
-        void setBasePose(double x, double y, double theta);
 
     private:
         static const std::string DEFAULT_URDF;        ///< Default URDF

--- a/robowflex_library/include/robowflex_library/detail/stretch.h
+++ b/robowflex_library/include/robowflex_library/detail/stretch.h
@@ -34,7 +34,7 @@ namespace robowflex
         /** \brief Initialize the robot with stretch_arm, stretch_gripper and stretch_head kinematics.
          *  \return True on success, false on failure.
          */
-        bool initialize();
+        bool initialize(bool addVirtual = true);
 
         /** \brief Points the Stretch's head to a point in the world frame.
          *  \param[in] point The point to look at.
@@ -48,6 +48,8 @@ namespace robowflex
         /** \brief Closes the Stretch's gripper.
          */
         void closeGripper();
+        
+        void setBasePose(double x, double y, double theta);
 
     private:
         static const std::string DEFAULT_URDF;        ///< Default URDF

--- a/robowflex_library/include/robowflex_library/robot.h
+++ b/robowflex_library/include/robowflex_library/robot.h
@@ -191,12 +191,32 @@ namespace robowflex
         void setSRDFPostProcessAddFloatingJoint(const std::string &name);
 
         /** \brief Adds a planning group with name \name and members \members, where each element is a pair
-         * that contains the type of group (first) and its name (second).
-         *  \param[in] name Name for new joint.
+         * that contains the type (joint, link, group, etc) and its name.
+         *  \param[in] name Name of new group.
          *  \param[in] members Members (type, name) that make up the planning group.
          */
-        void setSRDFPostProcessAddJointGroup(const std::string &name,
-                                             const std::vector<std::pair<std::string, std::string>> &members);
+        void setSRDFPostProcessAddGroup(const std::string &name,
+                                        const std::vector<std::pair<std::string, std::string>> &members);
+
+        /** \brief Adds a mobile manipulator group composed of one group for the mobile base and another one
+         * for the manipulator.
+         *  \param[in] base_group Name to be given to the mobile base group.
+         *  \param[in] manip_group Name of the existing manipulator group.
+         *  \param[in] base_manip_group Name to be given to
+         * the mobile base manipulator group.
+         */
+        void setSRDFPostProcessAddMobileManipulatorGroup(const std::string &base_group,
+                                                         const std::string &manip_group,
+                                                         const std::string &base_manip_group);
+
+        /** \brief Adds a mobile manipulator solver plugin to the kinematics configuration description.
+         *  \param[in] base_manip_group Name of the base manipulator group.
+         *  \param[in] search_resolution Search resolution parameter for the kinematics solver.
+         *  \param[in] timeout Timeout parameter for the kinematics solver.
+         */
+        void setKinematicsPostProcessAddBaseManipulatorPlugin(const std::string &base_manip_group,
+                                                              double search_resolution = 0.005,
+                                                              double timeout = 0.1);
 
         /** \brief Loads the kinematics plugin for a joint group and its subgroups. No kinematics are loaded
          * by default.

--- a/robowflex_library/include/robowflex_library/robot.h
+++ b/robowflex_library/include/robowflex_library/robot.h
@@ -190,6 +190,14 @@ namespace robowflex
          */
         void setSRDFPostProcessAddFloatingJoint(const std::string &name);
 
+        /** \brief Adds a planning group with name \name and members \members, where each element is a pair
+         * that contains the type of group (first) and its name (second).
+         *  \param[in] name Name for new joint.
+         *  \param[in] members Members (type, name) that make up the planning group.
+         */
+        void setSRDFPostProcessAddJointGroup(const std::string &name,
+                                             const std::vector<std::pair<std::string, std::string>> &members);
+
         /** \brief Loads the kinematics plugin for a joint group and its subgroups. No kinematics are loaded
          * by default.
          *  \param[in] group Joint group name to load.

--- a/robowflex_library/scripts/stretch_test.cpp
+++ b/robowflex_library/scripts/stretch_test.cpp
@@ -1,0 +1,67 @@
+/* Author: Carlos Quintero-Peña */
+
+#include <robowflex_library/builder.h>
+#include <robowflex_library/detail/stretch.h>
+#include <robowflex_library/scene.h>
+#include <robowflex_library/trajectory.h>
+#include <robowflex_library/util.h>
+#include <robowflex_library/random.h>
+#include <robowflex_library/io/visualization.h>
+#include <robowflex_library/log.h>
+
+using namespace robowflex;
+
+/* \file stretch_test.cpp
+ * A simple script that demonstrates motion planning with the Stretch robot. The
+ * resulting trajectory is output to a YAML file. This file can be visualized
+ * using Blender. See the corresponding robowflex_visualization readme.
+ */
+
+static const std::string GROUP = "stretch_arm";
+
+int main(int argc, char **argv)
+{
+    // Startup ROS
+    ROS ros(argc, argv);
+
+    // Create the default Stretch robot.
+    auto stretch = std::make_shared<StretchRobot>();
+    stretch->initialize();
+
+    // Open Gripper
+    stretch->openGripper();
+
+    // Create an empty scene.
+    auto scene = std::make_shared<Scene>(stretch);
+    scene->toYAMLFile("ex_stretch.yml");
+
+    // Create the default planner for the Stretch.
+    auto planner = std::make_shared<OMPL::StretchOMPLPipelinePlanner>(stretch, "default");
+    planner->initialize();
+
+    // Sets the Stretch's head pose to look at a point.
+    stretch->pointHead({0, -2, 10});
+
+    // Create a motion planning request with a pose goal.
+    MotionRequestBuilder request(planner, GROUP);
+    stretch->setGroupState(GROUP, {0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0});  // home
+    request.setStartConfiguration(stretch->getScratchState());
+
+    stretch->setGroupState(GROUP, {0.9967, 0.0, 0.13, 0.13, 0.13, 0.13, 4});  // extended
+    request.setGoalConfiguration(stretch->getScratchState());
+
+    request.setConfig("RRTConnect");
+
+    // Do motion planning!
+    planning_interface::MotionPlanResponse res = planner->plan(scene, request.getRequest());
+    if (res.error_code_.val != moveit_msgs::MoveItErrorCodes::SUCCESS)
+        return 1;
+
+    // Create a trajectory object for better manipulation.
+    auto trajectory = std::make_shared<Trajectory>(res.trajectory_);
+
+    // Output path to a file for visualization.
+    trajectory->toYAMLFile("stretch_path.yml");
+
+    return 0;
+}

--- a/robowflex_library/scripts/stretch_visualization.cpp
+++ b/robowflex_library/scripts/stretch_visualization.cpp
@@ -1,0 +1,93 @@
+/* Author: Carlos Quintero-Peña */
+
+#include <robowflex_library/builder.h>
+#include <robowflex_library/detail/stretch.h>
+#include <robowflex_library/geometry.h>
+#include <robowflex_library/io/broadcaster.h>
+#include <robowflex_library/io/visualization.h>
+#include <robowflex_library/log.h>
+#include <robowflex_library/scene.h>
+#include <robowflex_library/trajectory.h>
+#include <robowflex_library/util.h>
+
+using namespace robowflex;
+
+/* \file stretch_visualization.cpp
+ * A simple script that demonstrates how to use RViz with Robowflex with the
+ * Stretch robot. See https://kavrakilab.github.io/robowflex/rviz.html for how to
+ * use RViz visualization. Here, the scene, start/goal states, and motion plan
+ * displayed in RViz.
+ */
+
+static const std::string GROUP = "stretch_arm";
+
+int main(int argc, char **argv)
+{
+    // Startup ROS
+    ROS ros(argc, argv);
+
+    // Create the default Stretch robot.
+    auto stretch = std::make_shared<StretchRobot>();
+    stretch->initialize();
+
+    // Create an RViz visualization helper. Publishes all topics and parameter under `/robowflex` by
+    // default.
+    IO::RVIZHelper rviz(stretch);
+    IO::RobotBroadcaster bc(stretch);
+    bc.start();
+
+    RBX_INFO("RViz Initialized! Press enter to continue (after your RViz is setup)...");
+    std::cin.get();
+
+    // Load a scene from a YAML file.
+    auto scene = std::make_shared<Scene>(stretch);
+    scene->fromYAMLFile("package://robowflex_library/yaml/test_stretch.yml");
+
+    // Create the default planner for the Stretch.
+    auto planner = std::make_shared<OMPL::StretchOMPLPipelinePlanner>(stretch, "default");
+    planner->initialize();
+
+    // Create a motion planning request.
+    MotionRequestBuilder request(planner, GROUP);
+    stretch->setGroupState(GROUP, {0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0});  // home
+    request.setStartConfiguration(stretch->getScratchState());
+
+    // Visualize the scene (start state) in RViz.
+    rviz.updateScene(scene);
+    ROS_INFO("Visualizing start state");
+    std::cin.get();
+
+    // Create IK query.
+    auto query =
+        Robot::IKQuery(GROUP, "link_wrist_yaw", *stretch->getScratchState(), Eigen::Vector3d{0, 0.23, -0.71});
+    query.scene = scene;
+    stretch->setFromIK(query);
+    request.setGoalConfiguration(stretch->getScratchState());
+
+    // Visualize the goal state in RViz.
+    scene->getCurrentState() = *stretch->getScratchState();
+    rviz.updateScene(scene);
+    ROS_INFO("Visualizing goal state");
+    std::cin.get();
+
+    // Do motion planning!
+    planning_interface::MotionPlanResponse res = planner->plan(scene, request.getRequest());
+    if (res.error_code_.val != moveit_msgs::MoveItErrorCodes::SUCCESS)
+        return 1;
+
+    // Publish the trajectory to a topic to display in RViz.
+    rviz.updateTrajectory(res);
+    RBX_INFO("Visualizing trajectory.");
+    std::cin.get();
+
+    // Create a trajectory object for better manipulation.
+    auto trajectory = std::make_shared<Trajectory>(res.trajectory_);
+
+    // Output path to a file for visualization.
+    trajectory->toYAMLFile("stretch_pick.yml");
+
+    RBX_INFO("Press enter to exit.");
+    std::cin.get();
+
+    return 0;
+}

--- a/robowflex_library/src/detail/stretch.cpp
+++ b/robowflex_library/src/detail/stretch.cpp
@@ -33,8 +33,11 @@ StretchRobot::StretchRobot() : Robot("stretch")
 {
 }
 
-bool StretchRobot::initialize()
+bool StretchRobot::initialize(bool addVirtual)
 {
+    if (addVirtual)
+        setSRDFPostProcessAddPlanarJoint("base_joint");
+    
     bool success = false;
 
     // First attempt the `robowflex_resources` package, then attempt the "actual" resource files.
@@ -52,6 +55,8 @@ bool StretchRobot::initialize()
     loadKinematics("stretch_arm");
     loadKinematics("stretch_gripper");
     loadKinematics("stretch_head");
+//     loadKinematics("mobile_base");
+    loadKinematics("mobile_base_manipulator");
 
     StretchRobot::openGripper();
 
@@ -87,6 +92,21 @@ void StretchRobot::closeGripper()
                                                   {"joint_gripper_finger_right", 0.0}};
 
     Robot::setState(angles);
+}
+
+void StretchRobot::setBasePose(double x, double y, double theta)
+{
+    if (hasJoint("base_joint/x") && hasJoint("base_joint/y") && hasJoint("base_joint/theta"))
+    {
+        std::cout << "H" << std::endl;
+        const std::map<std::string, double> pose = {
+            {"base_joint/x", x}, {"base_joint/y", y}, {"base_joint/theta", theta}};
+
+        scratch_->setVariablePositions(pose);
+        scratch_->update();
+    }
+    else
+        RBX_WARN("base_joint does not exist, cannot move base! You need to set addVirtual to true");
 }
 
 OMPL::StretchOMPLPipelinePlanner::StretchOMPLPipelinePlanner(const RobotPtr &robot, const std::string &name)

--- a/robowflex_library/src/detail/stretch.cpp
+++ b/robowflex_library/src/detail/stretch.cpp
@@ -1,0 +1,103 @@
+/* Author: Carlos Quintero-Peña */
+
+#include <cmath>
+
+#include <robowflex_library/detail/stretch.h>
+#include <robowflex_library/io.h>
+#include <robowflex_library/log.h>
+
+using namespace robowflex;
+
+const std::string StretchRobot::DEFAULT_URDF{"package://stretch_description/urdf/stretch_description.xacro"};
+const std::string StretchRobot::DEFAULT_SRDF{"package://stretch_moveit_config/config/"
+                                             "stretch_description.srdf"};
+const std::string StretchRobot::DEFAULT_LIMITS{"package://stretch_moveit_config/config/joint_limits.yaml"};
+const std::string StretchRobot::DEFAULT_KINEMATICS{"package://stretch_moveit_config/config/kinematics.yaml"};
+const std::string  //
+    OMPL::StretchOMPLPipelinePlanner::DEFAULT_CONFIG{"package://stretch_moveit_config/config/"
+                                                     "ompl_planning.yaml"};
+
+const std::string StretchRobot::RESOURCE_URDF{"package://robowflex_resources/stretch/urdf/"
+                                              "stretch_description.xacro"};
+const std::string StretchRobot::RESOURCE_SRDF{"package://robowflex_resources/stretch/config/"
+                                              "stretch_description.srdf"};
+const std::string StretchRobot::RESOURCE_LIMITS{"package://robowflex_resources/stretch/config/"
+                                                "joint_limits.yaml"};
+const std::string  //
+    StretchRobot::RESOURCE_KINEMATICS{"package://robowflex_resources/stretch/config/kinematics.yaml"};
+const std::string  //
+    OMPL::StretchOMPLPipelinePlanner::RESOURCE_CONFIG{"package://robowflex_resources/stretch/config/"
+                                                      "ompl_planning.yaml"};
+
+StretchRobot::StretchRobot() : Robot("stretch")
+{
+}
+
+bool StretchRobot::initialize()
+{
+    bool success = false;
+
+    // First attempt the `robowflex_resources` package, then attempt the "actual" resource files.
+    if (IO::resolvePackage(RESOURCE_URDF).empty() or IO::resolvePackage(RESOURCE_SRDF).empty())
+    {
+        RBX_INFO("Initializing Stretch with `stretch_{description, moveit_config}`");
+        success = Robot::initialize(DEFAULT_URDF, DEFAULT_SRDF, DEFAULT_LIMITS, DEFAULT_KINEMATICS);
+    }
+    else
+    {
+        RBX_INFO("Initializing Stretch with `robowflex_resources`");
+        success = Robot::initialize(RESOURCE_URDF, RESOURCE_SRDF, RESOURCE_LIMITS, RESOURCE_KINEMATICS);
+    }
+
+    loadKinematics("stretch_arm");
+    loadKinematics("stretch_gripper");
+    loadKinematics("stretch_head");
+
+    StretchRobot::openGripper();
+
+    return success;
+}
+
+void StretchRobot::pointHead(const Eigen::Vector3d &point)
+{
+    const RobotPose point_pose = RobotPose(Eigen::Translation3d(point));
+    const RobotPose point_pan = getLinkTF("link_head_pan").inverse() * point_pose;
+    const RobotPose point_tilt = getLinkTF("link_head_tilt").inverse() * point_pose;
+
+    const double pan = atan2(point_pan.translation().y(), point_pan.translation().x());
+    const double tilt = -atan2(point_tilt.translation().z(),
+                               hypot(point_tilt.translation().x(), point_tilt.translation().y()));
+
+    const std::map<std::string, double> angles = {{"joint_head_pan", pan}, {"joint_head_tilt", tilt}};
+
+    Robot::setState(angles);
+}
+
+void StretchRobot::openGripper()
+{
+    const std::map<std::string, double> angles = {{"joint_gripper_finger_left", 0.3},
+                                                  {"joint_gripper_finger_right", 0.3}};
+
+    Robot::setState(angles);
+}
+
+void StretchRobot::closeGripper()
+{
+    const std::map<std::string, double> angles = {{"joint_gripper_finger_left", 0.0},
+                                                  {"joint_gripper_finger_right", 0.0}};
+
+    Robot::setState(angles);
+}
+
+OMPL::StretchOMPLPipelinePlanner::StretchOMPLPipelinePlanner(const RobotPtr &robot, const std::string &name)
+  : OMPLPipelinePlanner(robot, name)
+{
+}
+
+bool OMPL::StretchOMPLPipelinePlanner::initialize(const Settings &settings,
+                                                  const std::vector<std::string> &adapters)
+{
+    if (IO::resolvePackage(RESOURCE_CONFIG).empty())
+        return OMPLPipelinePlanner::initialize(DEFAULT_CONFIG, settings, DEFAULT_PLUGIN, adapters);
+    return OMPLPipelinePlanner::initialize(RESOURCE_CONFIG, settings, DEFAULT_PLUGIN, adapters);
+}

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -452,7 +452,7 @@ void Robot::setSRDFPostProcessAddFloatingJoint(const std::string &name)
 void Robot::setSRDFPostProcessAddGroup(const std::string &name,
                                        const std::vector<std::pair<std::string, std::string>> &members)
 {
-    setSRDFPostProcessFunction([&name, &members](tinyxml2::XMLDocument &doc) -> bool {
+    setSRDFPostProcessFunction([&, name, members](tinyxml2::XMLDocument &doc) -> bool {
         tinyxml2::XMLElement *group_element = doc.NewElement("group");
         group_element->SetAttribute("name", name.c_str());
 

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -350,6 +350,8 @@ bool Robot::loadKinematics(const std::string &group_name, bool load_subgroups)
     robot_model::SolverAllocatorFn allocator = kinematics_->getLoaderFunction(loader_->getSRDF());
 
     const auto &groups = kinematics_->getKnownGroups();
+    for (const auto &g : groups)
+        std::cout << g << std::endl;
     if (groups.empty())
     {
         RBX_ERROR("No kinematics plugins defined. Fill and load kinematics.yaml!");
@@ -379,6 +381,7 @@ bool Robot::loadKinematics(const std::string &group_name, bool load_subgroups)
 
     for (const auto &name : load_names)
     {
+        std::cout << name << std::endl;
         // Check if kinematics have already been loaded for this group.
         if (imap_.find(name) != imap_.end())
             continue;
@@ -387,7 +390,7 @@ bool Robot::loadKinematics(const std::string &group_name, bool load_subgroups)
             std::find(groups.begin(), groups.end(), name) == groups.end())
         {
             RBX_ERROR("No JMG or Kinematics defined for `%s`!", name);
-            return false;
+            continue;
         }
 
         robot_model::JointModelGroup *jmg = model_->getJointModelGroup(name);
@@ -866,6 +869,8 @@ bool Robot::setFromIK(const IKQuery &query, robot_state::RobotState &state) cons
         // Sample new target poses from regions.
         query.sampleRegions(targets);
 
+        std::cout << "Number of tips " << tips.size() << ", number of targets " << targets.size() << std::endl;
+        
 #if ROBOWFLEX_AT_LEAST_MELODIC
         // Multi-tip IK: Will delegate automatically to RobotState::setFromIKSubgroups() if the kinematics
         // solver doesn't support multi-tip queries.

--- a/robowflex_library/yaml/test_stretch.yml
+++ b/robowflex_library/yaml/test_stretch.yml
@@ -2,14 +2,10 @@ name: (noname)
 robot_state:
   joint_state:
     position: [0, 0, 0, 0, 0, 0, 0.1, 0, 0, 0, 0, 0]
-    header:
-      frame_id: base_link
     name: [joint_left_wheel, joint_head_pan, joint_head_tilt, joint_lift, joint_arm_l3, joint_arm_l2, joint_arm_l1, joint_arm_l0, joint_wrist_yaw, joint_gripper_finger_left, joint_gripper_finger_right, joint_right_wheel]
 robot_model_name: stretch
 fixed_frame_transforms:
-  - header:
-      frame_id: base_link
-    child_frame_id: base_link
+  - child_frame_id: world
     transform:
       translation: [0, 0, 0]
       rotation: [0, 0, 0, 1]
@@ -20,7 +16,7 @@ world:
         - resource: "package://robowflex_resources/objects/cafe_table.dae"
           dimensions: [0.025, 0.025, 0.025]
       mesh_poses:
-        - position: [0, -1.0, -0.08]
+        - position: [0, -1.05, -0.08]
           orientation: [0, 0, 0, 1]
     - id: Cube1
       primitives:

--- a/robowflex_library/yaml/test_stretch.yml
+++ b/robowflex_library/yaml/test_stretch.yml
@@ -1,0 +1,45 @@
+name: (noname)
+robot_state:
+  joint_state:
+    position: [0, 0, 0, 0, 0, 0, 0.1, 0, 0, 0, 0, 0]
+    header:
+      frame_id: base_link
+    name: [joint_left_wheel, joint_head_pan, joint_head_tilt, joint_lift, joint_arm_l3, joint_arm_l2, joint_arm_l1, joint_arm_l0, joint_wrist_yaw, joint_gripper_finger_left, joint_gripper_finger_right, joint_right_wheel]
+robot_model_name: stretch
+fixed_frame_transforms:
+  - header:
+      frame_id: base_link
+    child_frame_id: base_link
+    transform:
+      translation: [0, 0, 0]
+      rotation: [0, 0, 0, 1]
+world:
+  collision_objects:
+    - id: table_right
+      meshes:
+        - resource: "package://robowflex_resources/objects/cafe_table.dae"
+          dimensions: [0.025, 0.025, 0.025]
+      mesh_poses:
+        - position: [0, -1.0, -0.08]
+          orientation: [0, 0, 0, 1]
+    - id: Cube1
+      primitives:
+        - type: box
+          dimensions: [0.07, 0.07, 0.07]
+      primitive_poses:
+        - position: [-0.225, -0.68, 0.72]
+          orientation: [0, 0, 0, 1]      
+    - id: Cube2
+      primitives:
+        - type: box
+          dimensions: [0.07, 0.07, 0.07]
+      primitive_poses:
+        - position: [-0.025, -0.68, 0.72]
+          orientation: [0, 0, 0, 1]
+    - id: Cube3
+      primitives:
+        - type: box
+          dimensions: [0.07, 0.07, 0.07]
+      primitive_poses:
+        - position: [0.175, -0.68, 0.72]
+          orientation: [0, 0, 0, 1]


### PR DESCRIPTION
- Creates a convenience class for the Stretch robot/planning and two test scripts.
- Adds functions to the robot class to enable mobile manipulation planning. This feature relies on the existence of a kinematics solver plugin called `base_manipulator_kinematics_plugin`. See [here](https://github.com/KavrakiLab/base_manipulator_kinematics_plugin).