### PR TITLE
Fetch use lower limit

### DIFF
--- a/robowflex_library/include/robowflex_library/detail/fetch.h
+++ b/robowflex_library/include/robowflex_library/detail/fetch.h
@@ -72,6 +72,7 @@ namespace robowflex
         static const std::string RESOURCE_URDF;        ///< URDF from robowflex_resources
         static const std::string RESOURCE_SRDF;        ///< SRDF from robowflex_resources
         static const std::string RESOURCE_LIMITS;      ///< Limits from robowflex_resources
+        static const std::string RESOURCE_LIMITS_LOW;  ///< Lower limits from robowflex_resources
         static const std::string RESOURCE_KINEMATICS;  ///< kinematics from robowflex_resources
     };
 

--- a/robowflex_library/include/robowflex_library/detail/fetch.h
+++ b/robowflex_library/include/robowflex_library/detail/fetch.h
@@ -32,9 +32,10 @@ namespace robowflex
 
         /** \brief Initialize the robot with arm and arm_with_torso kinematics.
          *  \param[in] addVirtual flag to add virtual joint.
+         *  \param[in] use_low_limits flag to use lower joint limits.
          *  \return True on success, false on failure.
          */
-        bool initialize(bool addVirtual = true);
+        bool initialize(bool addVirtual = true, bool use_low_limits = false);
 
         /** \brief Inserts the caster links if they don't exist.
          *  \param[in] doc urdf description to be processed.

--- a/robowflex_library/include/robowflex_library/robot.h
+++ b/robowflex_library/include/robowflex_library/robot.h
@@ -771,7 +771,7 @@ namespace robowflex
          *  \param[in] namespaced Whether or not the parameter server description is under the handler
          * namespace.
          */
-        void initializeInternal(bool namespaced = true);
+        void initializeInternal(bool namespaced = true, const std::string &limits_file = "");
 
         /** \brief Loads a robot model from the loaded information on the parameter server.
          *  \param[in] description Robot description on parameter server.

--- a/robowflex_library/src/detail/fetch.cpp
+++ b/robowflex_library/src/detail/fetch.cpp
@@ -19,6 +19,8 @@ const std::string FetchRobot::RESOURCE_URDF{"package://robowflex_resources/fetch
 const std::string FetchRobot::RESOURCE_SRDF{"package://robowflex_resources/fetch/config/fetch.srdf"};
 const std::string FetchRobot::RESOURCE_LIMITS{"package://robowflex_resources/fetch/config/joint_limits.yaml"};
 const std::string  //
+    FetchRobot::RESOURCE_LIMITS_LOW{"package://robowflex_resources/fetch/config/joint_limits_low.yaml"};
+const std::string  //
     FetchRobot::RESOURCE_KINEMATICS{"package://robowflex_resources/fetch/config/kinematics.yaml"};
 const std::string  //
     OMPL::FetchOMPLPipelinePlanner::RESOURCE_CONFIG{"package://robowflex_resources/fetch/config/"
@@ -28,7 +30,7 @@ FetchRobot::FetchRobot() : Robot("fetch")
 {
 }
 
-bool FetchRobot::initialize(bool addVirtual)
+bool FetchRobot::initialize(bool addVirtual, bool use_low_limits)
 {
     if (addVirtual)
         setSRDFPostProcessAddPlanarJoint("base_joint");
@@ -36,7 +38,6 @@ bool FetchRobot::initialize(bool addVirtual)
     setURDFPostProcessFunction([this](tinyxml2::XMLDocument &doc) { return addCastersURDF(doc); });
 
     bool success = false;
-
     // First attempt the `robowflex_resources` package, then attempt the "actual" resource files.
     if (IO::resolvePackage(RESOURCE_URDF).empty() or IO::resolvePackage(RESOURCE_SRDF).empty())
     {
@@ -46,7 +47,11 @@ bool FetchRobot::initialize(bool addVirtual)
     else
     {
         RBX_INFO("Initializing Fetch with `robowflex_resources`");
-        success = Robot::initialize(RESOURCE_URDF, RESOURCE_SRDF, RESOURCE_LIMITS, RESOURCE_KINEMATICS);
+        if (use_low_limits)
+            success =
+                Robot::initialize(RESOURCE_URDF, RESOURCE_SRDF, RESOURCE_LIMITS_LOW, RESOURCE_KINEMATICS);
+        else
+            success = Robot::initialize(RESOURCE_URDF, RESOURCE_SRDF, RESOURCE_LIMITS, RESOURCE_KINEMATICS);
     }
 
     loadKinematics("arm");


### PR DESCRIPTION
The joint limits file was not correctly loaded because moveit does not load it when urdf and srdf is available. Now we check and load the joint limits correctly when a file is provided.