### PR TITLE
feature: apply clang-format to PRs before merge

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,27 @@
+name: Clang Format
+
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+    branches: [ master ]
+
+jobs:
+  jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.14
+      with:
+        source: '.'
+        exclude: './docs'
+        extensions: 'h,cpp,c,cc,hh,hpp'
+        clangFormatVersion: 14
+        inplace: True
+    - uses: EndBug/add-and-commit@v9
+      with:
+        author_name: clang-format bot
+        author_email: clangformat@kavrakilab.org # Fake email
+        message: 'Format with clang-format'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR attempts to add a new Github workflow that should apply `clang-format` in-place to commits in PRs. The idea is that this lets us automatically apply formatting while still allowing a chance to fix weird formatting issues before merging.

Note that, because this PR is a workflow for PRs, it isn't tested yet, and may need tweaking.
