### PR TITLE
YAML decode - Allow sec nsec duration format

### DIFF
--- a/robowflex_library/src/yaml.cpp
+++ b/robowflex_library/src/yaml.cpp
@@ -1258,7 +1258,20 @@ namespace YAML
 
     bool convert<ros::Duration>::decode(const Node &node, ros::Duration &rhs)
     {
-        rhs.fromSec(node.as<double>());
+        if (node.Type == NodeType::Scalar) {
+            rhs.fromSec(node.as<double>());
+            return true;
+        }
+        try
+        {
+            rhs.sec = node["sec"].as<int>();
+            rhs.nsec = node["nsec"].as<int>();
+        }
+        catch (YAML::InvalidNode &e)
+        {
+            rhs.sec = node["secs"].as<int>();
+            rhs.nsec = node["nsecs"].as<int>();
+        }
         return true;
     }
 

--- a/robowflex_library/src/yaml.cpp
+++ b/robowflex_library/src/yaml.cpp
@@ -1258,7 +1258,7 @@ namespace YAML
 
     bool convert<ros::Duration>::decode(const Node &node, ros::Duration &rhs)
     {
-        if (node.Type == NodeType::Scalar) {
+        if (node.Type() == NodeType::Scalar) {
             rhs.fromSec(node.as<double>());
             return true;
         }


### PR DESCRIPTION
Some yaml encoders save durations with the secs and nsecs fields instead of as a double.
The proposed changes allow for this format in the event that the node is not a single scalar value and maintain functionality otherwise.
No changes are made to the yaml encoder.