### PR TITLE
Blender/Pyyaml Compatibility and Type checking

### DIFF
--- a/robowflex_dart/scripts/fetch_se2.cpp
+++ b/robowflex_dart/scripts/fetch_se2.cpp
@@ -45,9 +45,9 @@ int main(int argc, char **argv)
     auto scene = std::make_shared<darts::Structure>("object");
     scene->addGround(-0.01, 10);
 
-    unsigned int nobs = 20;
+    size_t nobs = 20;
 
-    for (int i = 0; i < nobs; ++i)
+    for (size_t i = 0; i < nobs; ++i)
     {
         dart::dynamics::WeldJoint::Properties box_joint;
         box_joint.mName = log::format("box%1%", i);
@@ -56,8 +56,8 @@ int main(int argc, char **argv)
         scene->addWeldedFrame(box_joint, darts::makeBox(0.5, 0.5, 1));
     }
 
-    for (int i = 0; i < nobs; ++i)
-        for (int j = i + 1; j < nobs; ++j)
+    for (size_t i = 0; i < nobs; ++i)
+        for (size_t j = i + 1; j < nobs; ++j)
             scene->getACM()->disableCollision(log::format("box%1%", i), log::format("box%1%", j));
 
     world->addStructure(scene);

--- a/robowflex_visualization/robowflex_visualization/robot.py
+++ b/robowflex_visualization/robowflex_visualization/robot.py
@@ -273,7 +273,7 @@ class Robot:
                     self.set_joint_tf(name, tf, interpolate or i > 0)
                     self.add_keyframe(name, frame)
 
-        return last_frame
+        return math.ceil(last_frame)
 
     ## @brief Sets the robot's state from a file with a moveit_msgs::RobotState
     #

--- a/robowflex_visualization/robowflex_visualization/utils.py
+++ b/robowflex_visualization/robowflex_visualization/utils.py
@@ -354,7 +354,7 @@ def read_YAML_data(file_name):
         logging.warn('Cannot open {}'.format(file_name))
         return None
     with open(full_name) as input_file:
-        return yaml.load(input_file.read())
+        return yaml.load(input_file.read(), Loader=yaml.SafeLoader)
 
 
 def remove_doubles(item, threshold = 0.0001):


### PR DESCRIPTION
This PR:
- Fixes a comparison between uint and int error in `robowflex_dart` 
- Fixes compatibility with Blender 3.4 by casting the frame number output `animate_path` to be an int rather than a float
- Adds a Loader argument that is now required for pyyaml 6.0