### PR TITLE
feature: Expose composite world collision filter

### DIFF
--- a/robowflex_dart/include/robowflex_dart/world.h
+++ b/robowflex_dart/include/robowflex_dart/world.h
@@ -253,6 +253,13 @@ namespace robowflex
              */
             CollisionInfo getCollisionInfo(const std::string &name) const;
 
+            /** \brief Get the current world collision filter (composite of all skeleton filters).
+             * This is more efficient than constructing a new filter from
+             * robowflex::darts::World::getDefaultFilter() or robowflex::darts::World::getAllValidFilter().
+             * \return A pointer to the current world collision filter.
+             */
+            std::shared_ptr<const dart::collision::CompositeCollisionFilter> getWorldCollisionFilter() const;
+
         private:
             /** \brief Add a new collision filter (ACM) for a skeleton.
              *  \param[in] name Name for collision filter.

--- a/robowflex_dart/include/robowflex_dart/world.h
+++ b/robowflex_dart/include/robowflex_dart/world.h
@@ -248,8 +248,9 @@ namespace robowflex
             };
 
             /** \brief Get the collision info (self and other collision groups) for a skeleton in this
-             * world. \param[in] name The name of the skeleton. \return A struct containing pointers to
-             * the skeleton's self and other collision groups.
+             * world.
+             * \param[in] name The name of the skeleton.
+             * \return A struct containing pointers to the skeleton's self and other collision groups.
              */
             CollisionInfo getCollisionInfo(const std::string &name) const;
 

--- a/robowflex_dart/src/world.cpp
+++ b/robowflex_dart/src/world.cpp
@@ -365,3 +365,14 @@ World::CollisionInfo World::getCollisionInfo(const std::string &name) const
 {
     return collision_.at(name);
 }
+
+std::shared_ptr<const dart::collision::CompositeCollisionFilter>
+robowflex::darts::World::getWorldCollisionFilter() const
+{
+    if (filter_ == nullptr)
+    {
+        throw std::runtime_error("World collision filter is not initialized!");
+    }
+
+    return filter_;
+}


### PR DESCRIPTION
This allows the collision filter that is constructed when building or cloning a world to be accessed by users of the world, without the need to rebuild the filter using one of the existing methods.
This is useful for applications which need to do finer-grained collision checking than the `robowflex` API supports directly.

The PR also includes a documentation format fix I happened to notice while adding the new method.
