### PR TITLE
fix: Make returned world collision filter mutable

### DIFF
--- a/robowflex_dart/include/robowflex_dart/world.h
+++ b/robowflex_dart/include/robowflex_dart/world.h
@@ -259,7 +259,7 @@ namespace robowflex
              * robowflex::darts::World::getDefaultFilter() or robowflex::darts::World::getAllValidFilter().
              * \return A pointer to the current world collision filter.
              */
-            std::shared_ptr<const dart::collision::CompositeCollisionFilter> getWorldCollisionFilter() const;
+            std::shared_ptr<dart::collision::CompositeCollisionFilter> &getWorldCollisionFilter();
 
         private:
             /** \brief Add a new collision filter (ACM) for a skeleton.

--- a/robowflex_dart/src/world.cpp
+++ b/robowflex_dart/src/world.cpp
@@ -366,8 +366,7 @@ World::CollisionInfo World::getCollisionInfo(const std::string &name) const
     return collision_.at(name);
 }
 
-std::shared_ptr<const dart::collision::CompositeCollisionFilter>
-robowflex::darts::World::getWorldCollisionFilter() const
+std::shared_ptr<dart::collision::CompositeCollisionFilter> &robowflex::darts::World::getWorldCollisionFilter()
 {
     if (filter_ == nullptr)
     {


### PR DESCRIPTION
Dart's CollisionOption struct needs a mutable `CollisionFilter` pointer. This PR changes the `getWorldCollisionFilter` API to return such a pointer.
