### PR TITLE
Feature: Expose constant view of world structures

### DIFF
--- a/robowflex_dart/include/robowflex_dart/world.h
+++ b/robowflex_dart/include/robowflex_dart/world.h
@@ -90,7 +90,7 @@ namespace robowflex
             /** \brief Remove a robot from the world.
              *  \param[in] robot Robot to remove.
              */
-            void removeRobot(RobotPtr robot);
+            void removeRobot(const RobotPtr &robot);
 
             /** \brief Get a robot in the world.
              *  \param[in] name Name of robot to get.
@@ -111,7 +111,7 @@ namespace robowflex
             /** \brief Remove a structure from the world.
              *  \param[in] structure Structure to remove.
              */
-            void removeStructure(StructurePtr structure);
+            void removeStructure(const StructurePtr &structure);
 
             /** \brief Get a structure in the world.
              *  \param[in] name Name of structure to get.

--- a/robowflex_dart/include/robowflex_dart/world.h
+++ b/robowflex_dart/include/robowflex_dart/world.h
@@ -119,6 +119,11 @@ namespace robowflex
              */
             StructurePtr getStructure(const std::string &name);
 
+            /** \brief Get the set of structures in the world.
+             *  \return A constant reference to the set of structures.
+             */
+            const std::map<std::string, StructurePtr> &getStructures();
+
             /** \} */
 
             /** \name Getters and Setters

--- a/robowflex_dart/src/world.cpp
+++ b/robowflex_dart/src/world.cpp
@@ -193,6 +193,11 @@ StructurePtr World::getStructure(const std::string &name)
     return nullptr;
 }
 
+const std::map<std::string, StructurePtr> &World::getStructures()
+{
+    return structures_;
+}
+
 std::pair<Eigen::Vector3d, Eigen::Vector3d> World::getWorkspaceBounds() const
 {
     return std::make_pair(low_, high_);

--- a/robowflex_dart/src/world.cpp
+++ b/robowflex_dart/src/world.cpp
@@ -137,7 +137,7 @@ void World::removeRobot(const std::string &name)
     }
 }
 
-void World::removeRobot(RobotPtr robot)
+void World::removeRobot(const RobotPtr &robot)
 {
     removeRobot(robot->getName());
 }
@@ -179,7 +179,7 @@ void World::removeStructure(const std::string &name)
     }
 }
 
-void World::removeStructure(StructurePtr structure)
+void World::removeStructure(const StructurePtr &structure)
 {
     removeStructure(structure->getName());
 }


### PR DESCRIPTION
This PR exposes a constant view of the structures added to a `World`, to allow for easier manipulation without separately maintaining a list of structure names or pointers.

This is useful for, e.g., creating objects-only collision filters.
