### PR TITLE
Fixing ObjectGraspPose transforms

### DIFF
--- a/robowflex_library/include/robowflex_library/scene.h
+++ b/robowflex_library/include/robowflex_library/scene.h
@@ -163,7 +163,7 @@ namespace robowflex
 
         /** \brief Get a pose in the global frame relative to a collision object for grasping.
          *  \param[in] name Name of object to get pose for.
-         *  \param[in] offset The offset of the grasp.
+         *  \param[in] offset The offset of the grasp in the object's frame.
          *  \return Pose of the grasp offset from the object.
          */
         RobotPose getObjectGraspPose(const std::string &name, const RobotPose &offset) const;

--- a/robowflex_library/src/scene.cpp
+++ b/robowflex_library/src/scene.cpp
@@ -288,11 +288,7 @@ RobotPose Scene::getObjectGraspPose(const std::string &name, const RobotPose &of
     if (not hasObject(name))
         throw Exception(1, log::format("Object `%1%` not in scene!", name));
 
-    const auto model = getSceneConst()->getRobotModel();
-    const auto rpose = getCurrentStateConst().getGlobalLinkTransform(model->getRootLinkName());
-    const auto opose = getObjectPose(name);
-
-    return rpose * opose * offset;
+    return getObjectPose(name) * offset;
 }
 
 bool Scene::moveAllObjectsGlobal(const RobotPose &transform)


### PR DESCRIPTION
Closes #312 by removing extra robot pose transform from `getObjectGraspPose()`.