### PR TITLE
Add const duplicates for accessors to robots and structures in robowflex_dart::World

### DIFF
--- a/robowflex_dart/include/robowflex_dart/world.h
+++ b/robowflex_dart/include/robowflex_dart/world.h
@@ -185,7 +185,7 @@ namespace robowflex
              *  \param[in] skeleton The skeleton to get the index of.
              *  \return The index of a skeleton in the world.
              */
-            unsigned int getSkeletonIndex(dart::dynamics::SkeletonPtr skeleton) const;
+            unsigned int getSkeletonIndex(const dart::dynamics::SkeletonPtr &skeleton) const;
 
             /** \} */
 

--- a/robowflex_dart/include/robowflex_dart/world.h
+++ b/robowflex_dart/include/robowflex_dart/world.h
@@ -98,6 +98,12 @@ namespace robowflex
              */
             RobotPtr getRobot(const std::string &name);
 
+            /** \brief Get a robot in the world.
+             *  \param[in] name Name of robot to get.
+             *  \return The robot, or nullptr if non-existent.
+             */
+            RobotConstPtr getRobotConst(const std::string &name) const;
+
             /** \brief Add a structure to the world.
              *  \param[in] structure Structure to add.
              */
@@ -118,6 +124,12 @@ namespace robowflex
              *  \return The structure, or nullptr if non-existent.
              */
             StructurePtr getStructure(const std::string &name);
+
+            /** \brief Get a structure in the world.
+             *  \param[in] name Name of structure to get.
+             *  \return The structure, or nullptr if non-existent.
+             */
+            StructureConstPtr getStructureConst(const std::string &name) const;
 
             /** \brief Get the set of structures in the world.
              *  \return A constant reference to the set of structures.

--- a/robowflex_dart/src/world.cpp
+++ b/robowflex_dart/src/world.cpp
@@ -151,6 +151,15 @@ RobotPtr World::getRobot(const std::string &name)
     return nullptr;
 }
 
+RobotConstPtr World::getRobotConst(const std::string &name) const
+{
+    auto it = robots_.find(name);
+    if (it != robots_.end())
+        return it->second;
+
+    return nullptr;
+}
+
 void World::addStructure(StructurePtr structure)
 {
     auto it = structures_.find(structure->getName());
@@ -185,6 +194,15 @@ void World::removeStructure(const StructurePtr &structure)
 }
 
 StructurePtr World::getStructure(const std::string &name)
+{
+    auto it = structures_.find(name);
+    if (it != structures_.end())
+        return it->second;
+
+    return nullptr;
+}
+
+StructureConstPtr World::getStructureConst(const std::string &name) const
 {
     auto it = structures_.find(name);
     if (it != structures_.end())

--- a/robowflex_dart/src/world.cpp
+++ b/robowflex_dart/src/world.cpp
@@ -251,7 +251,7 @@ const dart::simulation::WorldPtr &World::getSimConst() const
     return world_;
 }
 
-unsigned int World::getSkeletonIndex(dart::dynamics::SkeletonPtr skeleton) const
+unsigned int World::getSkeletonIndex(const dart::dynamics::SkeletonPtr &skeleton) const
 {
     for (unsigned int i = 0; i < world_->getNumSkeletons(); ++i)
     {


### PR DESCRIPTION
- feat: Add const duplicates for getRobot and getStructure
- fix: Avoid unnecessary shared_ptr copy in getSkeletonIndex
