### PR TITLE
Allow use of robowflex_dart with C++20

### DIFF
--- a/robowflex_dart/include/robowflex_dart/robot.h
+++ b/robowflex_dart/include/robowflex_dart/robot.h
@@ -3,8 +3,10 @@
 #ifndef ROBOWFLEX_DART_ROBOT_
 #define ROBOWFLEX_DART_ROBOT_
 
+#ifndef ROBOWFLEX_DART_ONLY
 #include <moveit/robot_state/conversions.h>
 #include <moveit/robot_state/robot_state.h>
+#endif
 
 #include <dart/dynamics/Skeleton.hpp>
 #include <dart/collision/CollisionFilter.hpp>
@@ -95,6 +97,7 @@ namespace robowflex
             /** \name State Operations
                 \{ */
 
+#ifndef ROBOWFLEX_DART_ONLY
             /** \brief Set the current state of this robot from a MoveIt message.
              *  \param[in] msg Message to set state to.
              */
@@ -139,6 +142,7 @@ namespace robowflex
              */
             void setMoveItJMGFromState(const std::string &jmg, Eigen::Ref<Eigen::VectorXd> vec) const;
 
+#endif
             /** \} */
 
             /** \name Group Operations

--- a/robowflex_dart/src/robot.cpp
+++ b/robowflex_dart/src/robot.cpp
@@ -461,6 +461,7 @@ void Robot::setNamedGroupState(const std::string &group, const std::string &name
         it->second = q;
 }
 
+#ifndef ROBOWFLEX_DART_ONLY
 void Robot::setStateFromMoveItMsg(const moveit_msgs::RobotState &msg)
 {
     for (std::size_t i = 0; i < msg.joint_state.name.size(); ++i)
@@ -564,6 +565,7 @@ void Robot::setMoveItJMGFromState(const std::string &jmg, Eigen::Ref<Eigen::Vect
     setMoveItStateFromState(*robot_->getScratchState());                  // copy current state
     robot_->getScratchState()->copyJointGroupPositions(jmg, vec.data());  // copy JMG state
 }
+#endif
 
 void Robot::processGroup(const std::string &group)
 {


### PR DESCRIPTION
This may be a controversial PR - it's meant to allow use of `robowflex_dart` with C++20 projects, and potentially outside of `ROS`/`catkin` contexts.

Currently, it does so by adding the `ROBOWFLEX_DART_ONLY` compile definition, and using this to gate the features in `robowflex::darts::Robot` that use parts of MoveIt that are incompatible with C++20.
This suffices to allow C++20 projects that use only the rest of `robowflex_dart` to build.

However, this may be incomplete (i.e., there could be other parts of `robowflex_dart` that also need this gating applied), and it may not be the best way to achieve C++20 compatibility.
I have also not tested this for building outside of `catkin` yet.

Thoughts?
