### PR TITLE
Fixing IK for Grasping Objects

### DIFF
--- a/robowflex_library/include/robowflex_library/robot.h
+++ b/robowflex_library/include/robowflex_library/robot.h
@@ -519,12 +519,14 @@ namespace robowflex
              *  \param[in] scene Scene that object is in.
              *  \param[in] object Name of object to grasp.
              *  \param[in] tolerances Position tolerances on the XYZ axes for the grasp.
+             *  \param[in] verbose If true, will give verbose collision checking output.
              */
             IKQuery(const std::string &group,   //
                     const RobotPose &offset,    //
                     const ScenePtr &scene,      //
                     const std::string &object,  //
-                    const Eigen::Vector3d &tolerances = constants::ik_vec_tolerance);
+                    const Eigen::Vector3d &tolerances = constants::ik_vec_tolerance,
+                    bool verbose = false);
 
             /** \brief Constructor. Initialize an IK query from MoveIt message constraints.
              *  \param[in] group Group to set.

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -632,8 +632,9 @@ Robot::IKQuery::IKQuery(const std::string &group,   //
                         const RobotPose &offset,    //
                         const ScenePtr &scene,      //
                         const std::string &object,  //
-                        const Eigen::Vector3d &tolerances)
-  : group(group)
+                        const Eigen::Vector3d &tolerances,
+                        bool verbose)
+  : group(group), scene(scene), verbose(verbose)
 {
     const auto &pose = scene->getObjectGraspPose(object, offset);
     addRequest("",                                     //


### PR DESCRIPTION

<!--- Provide a general summary of the issue in the Title above -->
This PR fixes the following issues I have encountered with running inverse kinematics with a scene object as the argument.
1. The IKQuery when an object is provided does not perform collision checking with the provided scene, leading to invalid IK solutions.
2. When performing a single-tip query, we observe an error message and kinematic constraints are not applied during IK solving.
```cpp
Link '' not found in model 'my_robot'
[ WARN] [1683770738.195248063]: Position constraint link model  not found in kinematic model. Constraint invalid.
```

## Expected Behavior
<!--- Tell us what should happen -->
We should be able to perform IK relative to an object to find a goal pose that can be used to plan a path to grab an object. This IK should obey kinematic constraints and perform collision checking with the scene to ensure the final pose is feasible. 

## Current Behavior
<!--- Tell us what happens instead of the expected behavior -->
Creating an `IKQuery` using the object constructor leads to an error in constraint definition and does not perform collision checking with the scene.

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include code to reproduce, if relevant -->
1. Create a scene with a robot, goal object, and other obstacles.
2. Create an `IKQuery` with the object as a constructor
3. Run `setFromIK` using the given IKQuery and examine the console output and visualize the resulting state
4. Observe that the state is in collision with the environment.
5. Observe an error message stating that position constraint cannot be defined due to not finding `""` link in the kinematic model.

## The Fix
<!--- Provide a detailed description of the change or addition you are proposing -->

### Missing constraints 

When using the [`IKQuery` constructor that takes in an object](https://github.com/KavrakiLab/robowflex/blob/3738ba1026b0140d0e2808663732a3f89ef62f9a/robowflex_library/src/robot.cpp#L631-L643). A request is constructed with the empty string: `""` as the tip.

When this request is passed into `bool Robot::setFromIK(const IKQuery &query, robot_state::RobotState &state) const`, [this line](https://github.com/KavrakiLab/robowflex/blob/3738ba1026b0140d0e2808663732a3f89ef62f9a/robowflex_library/src/robot.cpp#L865-L868) attempts to create a new tips object that is set to the Tip frame of the query group.

The updated tips is then used in the call to `state.setFromIK` to invoke the actual IK [here](https://github.com/KavrakiLab/robowflex/blob/3738ba1026b0140d0e2808663732a3f89ef62f9a/robowflex_library/src/robot.cpp#L892).

However, the original `query.tips` is also used for other parts of the IK process, including defining constraints for the IK solver [here](https://github.com/KavrakiLab/robowflex/blob/3738ba1026b0140d0e2808663732a3f89ef62f9a/robowflex_library/src/robot.cpp#L876), where  `query.getAsConstraints` invokes `void Robot::IKQuery::getMessage() const` [here](https://github.com/KavrakiLab/robowflex/blob/3738ba1026b0140d0e2808663732a3f89ef62f9a/robowflex_library/src/robot.cpp#L815-L831), which uses the `query` object's `tips` to set the position and orientation constraints.

In this case, `tips[0]` is the empty string and results in no kinematic constraints being defined, which causes invalid IK solutions to be produced.

The solution implemented in this PR is to actually copy the query and not just the tips variable as [the comment](https://github.com/KavrakiLab/robowflex/blob/3738ba1026b0140d0e2808663732a3f89ef62f9a/robowflex_library/src/robot.cpp#L864) in the code seems to indicate, which will ensure the updated tips variable is used throughout in the calculation.

Alternatively, we can remove the const qualifier of the `IKQuery` object, but this would be a larger breaking change.

### Fixing Collision Checking

When using the [`IKQuery` constructor that takes in an object](https://github.com/KavrakiLab/robowflex/blob/3738ba1026b0140d0e2808663732a3f89ef62f9a/robowflex_library/src/robot.cpp#L631-L643), it turns out the constructor does not initialize the `scene` object of the `IKQuery`, causing the IK solver to use the default collision checking instead of the scene's. I fixed the construtor to properly initialize the Scene pointer as well as expose the `verbose` parameter for this constructor.
