### PR TITLE
Fix for SamplePoseGaussian not drawing from Gaussian Distribution

### DIFF
--- a/robowflex_library/include/robowflex_library/tf.h
+++ b/robowflex_library/include/robowflex_library/tf.h
@@ -225,13 +225,13 @@ namespace robowflex
          */
         RobotPose samplePoseUniform(const Eigen::Vector3d &pos_bounds, const Eigen::Vector3d &orn_bounds);
 
-        /** \brief Sample a pose with gaussian sampling for the position with given variances and
+        /** \brief Sample a pose with gaussian sampling for the position with given standard deviations and
          *  uniform sampling for the orientation within the given bounds.
-         *  \param[in] pos_variances The desired position variances.
+         *  \param[in] pos_stddev The desired position standard deviations.
          *  \param[in] orn_bounds The desired orientation bounds.
          *  \return The sampled pose.
          */
-        RobotPose samplePoseGaussian(const Eigen::Vector3d &pos_variances, const Eigen::Vector3d &orn_bounds);
+        RobotPose samplePoseGaussian(const Eigen::Vector3d &pos_stddev, const Eigen::Vector3d &orn_bounds);
 
         /** \brief Decode a message as a transform.
          *  \param[in] tf Transform message.

--- a/robowflex_library/include/robowflex_library/tf.h
+++ b/robowflex_library/include/robowflex_library/tf.h
@@ -191,11 +191,11 @@ namespace robowflex
         Eigen::Quaterniond sampleOrientation(const Eigen::Quaterniond &orientation,
                                              const Eigen::Vector3d &tolerances);
 
-        /** \brief Sample an orientation within the XYZ Euler angle \a bounds.
-         *  \param[in] bounds XYZ Euler angle bounds about orientation.
+        /** \brief Sample an orientation within the XYZ Euler angle \a tolerances.
+         *  \param[in] tolerances XYZ Euler angle tolerances about orientation.
          *  \return The sampled orientation.
          */
-        Eigen::Quaterniond sampleOrientationUniform(const Eigen::Vector3d &bounds);
+        Eigen::Quaterniond sampleOrientationUniform(const Eigen::Vector3d &tolerances);
 
         /** \brief Offset an orientation by a rotation about an axis.
          *  \param[in] orientation Orientation to offset.

--- a/robowflex_library/src/tf.cpp
+++ b/robowflex_library/src/tf.cpp
@@ -253,7 +253,7 @@ RobotPose TF::samplePoseUniform(const Eigen::Vector3d &pos_bounds, const Eigen::
 RobotPose TF::samplePoseGaussian(const Eigen::Vector3d &pos_variances, const Eigen::Vector3d &orn_bounds)
 {
     auto sampled = RobotPose::Identity();
-    sampled.translation() = samplePositionUniform(pos_variances);
+    sampled.translation() = samplePositionGaussian(pos_variances);
     sampled.linear() = sampleOrientationUniform(orn_bounds).toRotationMatrix();
 
     return sampled;

--- a/robowflex_library/src/tf.cpp
+++ b/robowflex_library/src/tf.cpp
@@ -250,10 +250,10 @@ RobotPose TF::samplePoseUniform(const Eigen::Vector3d &pos_bounds, const Eigen::
     return sampled;
 }
 
-RobotPose TF::samplePoseGaussian(const Eigen::Vector3d &pos_variances, const Eigen::Vector3d &orn_bounds)
+RobotPose TF::samplePoseGaussian(const Eigen::Vector3d &pos_stddev, const Eigen::Vector3d &orn_bounds)
 {
     auto sampled = RobotPose::Identity();
-    sampled.translation() = samplePositionGaussian(pos_variances);
+    sampled.translation() = samplePositionGaussian(pos_stddev);
     sampled.linear() = sampleOrientationUniform(orn_bounds).toRotationMatrix();
 
     return sampled;


### PR DESCRIPTION
This PR fixes the issue that [`samplePoseGaussian()`](https://github.com/KavrakiLab/robowflex/blob/0acef779971351fe46256a721bb7a7ce72944b73/robowflex_library/src/tf.cpp#L253-L260) is currently drawing positions from the uniform distribution instead of the Gaussian distribution.

## The Problem

Currently `samplePoseGaussian()` samples positions uniformly between `-pos_variances` and `+pos_variances`.

## Expected Behavior

`samplePoseGaussian()` should sample from the normal distribution: `N(0, pos_variances)`.

## The Fix

This PR fixes the issue by making `samplePoseGaussian()` call `samplePositionGaussian()` instead of `samplePositionUniform()`.

### Other changes

The input parameter to  `samplePoseGaussian()`  has also been renamed from `pos_variances` to `pos_stddev` to reflect that the input should be the standard deviation, not the variance (as reflected in the [documentation of `samplePositionGaussian()`](https://github.com/KavrakiLab/robowflex/blob/0acef779971351fe46256a721bb7a7ce72944b73/robowflex_library/include/robowflex_library/tf.h#L215-L219)).

Fixed a discrepency between the input parameter name in the function signature of `sampleOrientationUniform()` in [`tf.h`](https://github.com/KavrakiLab/robowflex/blob/0acef779971351fe46256a721bb7a7ce72944b73/robowflex_library/include/robowflex_library/tf.h#L198) and [`tf.cpp`](https://github.com/KavrakiLab/robowflex/blob/0acef779971351fe46256a721bb7a7ce72944b73/robowflex_library/src/tf.cpp#L218). 
